### PR TITLE
Ensure Shiny app loads required officer and flextable packages

### DIFF
--- a/app.R
+++ b/app.R
@@ -7,6 +7,8 @@ library(bslib)
 library(ggplot2)
 library(dplyr)
 library(DT)
+library(officer)
+library(flextable)
 
 source("R/module_upload.R")
 source("R/module_filter.R")


### PR DESCRIPTION
## Summary
- load the officer and flextable libraries in `app.R` so the Word export helpers can run without namespace errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f529a1a674832ba0e79be5b43fe2dd