### PR TITLE
Fix LM/LMM analysis panels rendering

### DIFF
--- a/R/module_analysis_regression.R
+++ b/R/module_analysis_regression.R
@@ -5,22 +5,27 @@
 regression_ui <- function(id, engine = c("lm", "lmm")) {
   ns <- NS(id)
   engine <- match.arg(engine)
-  tagList(
-    uiOutput(ns("variable_selectors")),
-    uiOutput(ns("interaction_select")),
-    hr(),
-    uiOutput(ns("formula_preview")),
-    br(),
-    fluidRow(
-      column(6, actionButton(ns("run"), "Run", width = "100%")),
-      column(6, downloadButton(ns("download_model"), "Download All Results", width = "100%"))
+
+  list(
+    config = tagList(
+      uiOutput(ns("variable_selectors")),
+      uiOutput(ns("interaction_select")),
+      hr(),
+      uiOutput(ns("formula_preview")),
+      br(),
+      fluidRow(
+        column(6, actionButton(ns("run"), "Run", width = "100%")),
+        column(6, downloadButton(ns("download_model"), "Download All Results", width = "100%"))
+      )
     ),
-    verbatimTextOutput(ns("fit_error")),
-    verbatimTextOutput(ns("full_summary")),
-    h5("Diagnostics"),
-    fluidRow(
-      column(6, plotOutput(ns("resid_plot"))),
-      column(6, plotOutput(ns("qq_plot")))
+    results = tagList(
+      verbatimTextOutput(ns("fit_error")),
+      verbatimTextOutput(ns("full_summary")),
+      h5("Diagnostics"),
+      fluidRow(
+        column(6, plotOutput(ns("resid_plot"))),
+        column(6, plotOutput(ns("qq_plot")))
+      )
     )
   )
 }


### PR DESCRIPTION
## Summary
- update the shared regression UI helper to return separate config and results slots
- ensure the Analyze tab can render the Linear Model and Linear Mixed Model submodules again

## Testing
- not run (Rscript binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f53e6bf960832b9ed4f66497fed2c5