### PR TITLE
Refactor filtered data reactive into helper

### DIFF
--- a/R/module_analysis_anova_one-way.R
+++ b/R/module_analysis_anova_one-way.R
@@ -32,10 +32,7 @@ one_way_anova_server <- function(id, filtered_data) {
     # -----------------------------------------------------------
     # Reactive data
     # -----------------------------------------------------------
-    df <- reactive({
-      req(filtered_data())
-      filtered_data()
-    })
+    df <- use_filtered_df(filtered_data)
     
     # -----------------------------------------------------------
     # Dynamic inputs

--- a/R/module_analysis_anova_two-way.R
+++ b/R/module_analysis_anova_two-way.R
@@ -31,10 +31,7 @@ two_way_anova_server <- function(id, filtered_data) {
     # -----------------------------------------------------------
     # Reactive data
     # -----------------------------------------------------------
-    df <- reactive({
-      req(filtered_data())
-      filtered_data()
-    })
+    df <- use_filtered_df(filtered_data)
     
     # -----------------------------------------------------------
     # Dynamic inputs

--- a/R/module_analysis_descriptive.R
+++ b/R/module_analysis_descriptive.R
@@ -27,10 +27,7 @@ descriptive_server <- function(id, filtered_data) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
-    df <- reactive({
-      req(filtered_data())
-      filtered_data()
-    })
+    df <- use_filtered_df(filtered_data)
     
     observe({
       data <- df()

--- a/R/module_visualize.R
+++ b/R/module_visualize.R
@@ -53,10 +53,7 @@ visualize_server <- function(id, filtered_data, model_fit) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
-    df <- reactive({
-      req(filtered_data())
-      filtered_data()
-    })
+    df <- use_filtered_df(filtered_data)
     
     model_info <- reactive({
       model_fit()

--- a/R/reactive_helpers.R
+++ b/R/reactive_helpers.R
@@ -1,0 +1,10 @@
+# ===============================================================
+# 🧰 Reactive helpers shared across modules
+# ===============================================================
+
+use_filtered_df <- function(filtered_data) {
+  reactive({
+    req(filtered_data())
+    filtered_data()
+  })
+}

--- a/app.R
+++ b/app.R
@@ -16,6 +16,7 @@ library(shinyjqui)
 library(skimr)
 library(tidyr)
 
+source("R/reactive_helpers.R")
 source("R/module_upload.R")
 source("R/module_filter.R")
 source("R/module_analysis.R")


### PR DESCRIPTION
## Summary
- add a shared helper that wraps filtered data access in a reactive with req()
- update descriptive, ANOVA, and visualization modules to use the helper
- source the helper in the app bootstrap so it is available to all modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f91f6dea28832b851c39638a6a9dec