### PR TITLE
Refactor visualization module into modular helpers

### DIFF
--- a/R/module_visualize_helpers.R
+++ b/R/module_visualize_helpers.R
@@ -141,3 +141,21 @@ compute_layout <- function(n_items, rows_input, cols_input) {
   )
 }
 
+build_layout_controls_for_type <- function(ns, input, info, default_ui_value, data_for_pca = NULL) {
+  current_type <- if (!is.null(info$type)) info$type else "anova"
+
+  if (identical(current_type, "anova") || identical(current_type, "two_way_anova")) {
+    return(build_anova_layout_controls(ns, input, info, default_ui_value))
+  }
+
+  if (identical(current_type, "ggpairs")) {
+    return(build_ggpairs_layout_controls())
+  }
+
+  if (identical(current_type, "pca")) {
+    return(build_pca_layout_controls(ns, data_for_pca))
+  }
+
+  NULL
+}
+

--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -1,0 +1,91 @@
+# ===============================================================
+# 🧱 Visualization Layout Management
+# ===============================================================
+
+initialize_layout_state <- function(input, session) {
+  layout_overrides <- reactiveValues(
+    strata_rows = 0,
+    strata_cols = 0,
+    resp_rows = 0,
+    resp_cols = 0
+  )
+
+  layout_manual <- reactiveValues(
+    strata_rows = FALSE,
+    strata_cols = FALSE,
+    resp_rows = FALSE,
+    resp_cols = FALSE
+  )
+
+  suppress_updates <- reactiveValues(
+    strata_rows = TRUE,
+    strata_cols = TRUE,
+    resp_rows = TRUE,
+    resp_cols = TRUE
+  )
+
+  observe_numeric_input <- function(name) {
+    observeEvent(input[[name]], {
+      if (isTRUE(suppress_updates[[name]])) {
+        suppress_updates[[name]] <- FALSE
+        return()
+      }
+
+      val <- suppressWarnings(as.numeric(input[[name]]))
+      if (is.na(val) || val <= 0) {
+        layout_overrides[[name]] <- 0L
+        layout_manual[[name]] <- FALSE
+      } else {
+        layout_overrides[[name]] <- as.integer(val)
+        layout_manual[[name]] <- TRUE
+      }
+    })
+  }
+  lapply(c("strata_rows", "strata_cols", "resp_rows", "resp_cols"), observe_numeric_input)
+
+  effective_input <- function(name) {
+    if (isTRUE(layout_manual[[name]])) layout_overrides[[name]] else 0
+  }
+
+  default_ui_value <- function(cur_val) {
+    val <- if (is.null(cur_val)) 1 else cur_val
+    ifelse(is.na(val) || val <= 0, 1, val)
+  }
+
+  list(
+    overrides = layout_overrides,
+    manual = layout_manual,
+    suppress = suppress_updates,
+    effective_input = effective_input,
+    default_ui_value = default_ui_value
+  )
+}
+
+observe_layout_synchronization <- function(plot_info_reactive, layout_state, session) {
+  observeEvent(plot_info_reactive(), {
+    info <- plot_info_reactive()
+    if (is.null(info)) return()
+
+    sync_input <- function(id, value, manual_key) {
+      val <- ifelse(is.null(value) || value <= 0, 1, value)
+      if (!isTRUE(layout_state$manual[[manual_key]])) {
+        layout_state$suppress[[id]] <- TRUE
+        updateNumericInput(session, id, value = val)
+      }
+    }
+
+    if (isTRUE(info$has_strata)) {
+      sync_input("strata_rows", info$layout$strata$rows, "strata_rows")
+      sync_input("strata_cols", info$layout$strata$cols, "strata_cols")
+    } else {
+      sync_input("strata_rows", 1, "strata_rows")
+      sync_input("strata_cols", 1, "strata_cols")
+    }
+
+    resp_rows_val <- if (info$n_responses <= 1) 1 else info$layout$responses$nrow
+    resp_cols_val <- if (info$n_responses <= 1) 1 else info$layout$responses$ncol
+
+    sync_input("resp_rows", resp_rows_val, "resp_rows")
+    sync_input("resp_cols", resp_cols_val, "resp_cols")
+  })
+}

--- a/R/module_visualize_plot_builders.R
+++ b/R/module_visualize_plot_builders.R
@@ -1,0 +1,192 @@
+# ===============================================================
+# 🎨 Visualization Plot Builders
+# ===============================================================
+
+build_anova_plot_info <- function(data, info, effective_input) {
+  factor1 <- info$factors$factor1
+  factor2 <- info$factors$factor2
+  order1 <- info$orders$order1
+  order2 <- info$orders$order2
+
+  if (!is.null(factor1) && !is.null(order1)) {
+    data[[factor1]] <- factor(data[[factor1]], levels = order1)
+  }
+  if (!is.null(factor2) && !is.null(order2)) {
+    data[[factor2]] <- factor(data[[factor2]], levels = order2)
+  }
+
+  responses <- info$responses
+  has_strata <- !is.null(info$strata) && !is.null(info$strata$var)
+  strat_var <- if (has_strata) info$strata$var else NULL
+  strata_levels <- if (has_strata) info$strata$levels else character(0)
+  if (has_strata && (is.null(strata_levels) || length(strata_levels) == 0)) {
+    strata_levels <- unique(as.character(stats::na.omit(data[[strat_var]])))
+  }
+
+  response_plots <- list()
+  max_strata_rows <- 1
+  max_strata_cols <- 1
+
+  compute_stats <- function(df_subset, resp_name) {
+    if (is.null(factor2)) {
+      df_subset |>
+        dplyr::group_by(.data[[factor1]]) |>
+        dplyr::summarise(
+          mean = mean(.data[[resp_name]], na.rm = TRUE),
+          se = sd(.data[[resp_name]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp_name]]))),
+          .groups = "drop"
+        )
+    } else {
+      df_subset |>
+        dplyr::group_by(.data[[factor1]], .data[[factor2]]) |>
+        dplyr::summarise(
+          mean = mean(.data[[resp_name]], na.rm = TRUE),
+          se = sd(.data[[resp_name]], na.rm = TRUE) / sqrt(sum(!is.na(.data[[resp_name]]))),
+          .groups = "drop"
+        )
+    }
+  }
+
+  build_plot <- function(stats_df, title_text, y_limits) {
+    if (is.null(factor2)) {
+      p <- ggplot(stats_df, aes(x = !!sym(factor1), y = mean)) +
+        geom_line(aes(group = 1), color = "steelblue", linewidth = 1) +
+        geom_point(size = 3, color = "steelblue") +
+        geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                      width = 0.15, color = "gray40") +
+        theme_minimal(base_size = 14) +
+        labs(x = factor1, y = "Mean ± SE") +
+        theme(
+          panel.grid.minor = element_blank(),
+          panel.grid.major.x = element_blank()
+        )
+    } else {
+      p <- ggplot(stats_df, aes(
+        x = !!sym(factor1),
+        y = mean,
+        color = !!sym(factor2),
+        group = !!sym(factor2)
+      )) +
+        geom_line(linewidth = 1) +
+        geom_point(size = 3) +
+        geom_errorbar(aes(ymin = mean - se, ymax = mean + se),
+                      width = 0.15) +
+        theme_minimal(base_size = 14) +
+        labs(
+          x = factor1,
+          y = "Mean ± SE",
+          color = factor2
+        ) +
+        theme(
+          panel.grid.minor = element_blank(),
+          panel.grid.major.x = element_blank()
+        )
+    }
+
+    if (!is.null(y_limits) && all(is.finite(y_limits))) {
+      p <- p + scale_y_continuous(limits = y_limits)
+    }
+
+    p + ggtitle(title_text) +
+      theme(plot.title = element_text(size = 12, face = "bold"))
+  }
+
+  for (resp in responses) {
+    if (has_strata) {
+      stratum_plots <- list()
+      y_values <- c()
+
+      for (stratum in strata_levels) {
+        subset_data <- data[!is.na(data[[strat_var]]) & data[[strat_var]] == stratum, , drop = FALSE]
+        if (nrow(subset_data) == 0) next
+
+        stats_df <- compute_stats(subset_data, resp)
+        if (nrow(stats_df) == 0) next
+
+        y_values <- c(y_values, stats_df$mean - stats_df$se, stats_df$mean + stats_df$se)
+        stratum_plots[[stratum]] <- stats_df
+      }
+
+      if (length(stratum_plots) == 0) next
+
+      y_limits <- range(y_values, na.rm = TRUE)
+      if (!all(is.finite(y_limits))) y_limits <- NULL
+
+      strata_plot_list <- lapply(names(stratum_plots), function(stratum_name) {
+        build_plot(stratum_plots[[stratum_name]], stratum_name, y_limits)
+      })
+
+      layout <- compute_layout(
+        length(strata_plot_list),
+        effective_input("strata_rows"),
+        effective_input("strata_cols")
+      )
+
+      max_strata_rows <- max(max_strata_rows, layout$nrow)
+      max_strata_cols <- max(max_strata_cols, layout$ncol)
+
+      combined <- patchwork::wrap_plots(
+        plotlist = strata_plot_list,
+        nrow = layout$nrow,
+        ncol = layout$ncol
+      )
+
+      title_plot <- ggplot() +
+        theme_void() +
+        ggtitle(resp) +
+        theme(
+          plot.title = element_text(size = 16, face = "bold", hjust = 0.5),
+          plot.margin = margin(t = 0, r = 0, b = 6, l = 0)
+        )
+
+      response_plots[[resp]] <- title_plot / combined + plot_layout(heights = c(0.08, 1))
+
+    } else {
+      stats_df <- compute_stats(data, resp)
+      if (nrow(stats_df) == 0) {
+        next
+      }
+
+      y_values <- c(stats_df$mean - stats_df$se, stats_df$mean + stats_df$se)
+      y_limits <- range(y_values, na.rm = TRUE)
+      if (!all(is.finite(y_limits))) {
+        y_limits <- NULL
+      }
+
+      response_plots[[resp]] <- build_plot(stats_df, resp, y_limits)
+      max_strata_rows <- max(max_strata_rows, 1)
+      max_strata_cols <- max(max_strata_cols, 1)
+    }
+  }
+
+  if (length(response_plots) == 0) {
+    return(NULL)
+  }
+
+  resp_layout <- compute_layout(
+    length(response_plots),
+    effective_input("resp_rows"),
+    effective_input("resp_cols")
+  )
+
+  final_plot <- if (length(response_plots) == 1) {
+    response_plots[[1]]
+  } else {
+    patchwork::wrap_plots(
+      plotlist = response_plots,
+      nrow = resp_layout$nrow,
+      ncol = resp_layout$ncol
+    ) &
+      patchwork::plot_layout(guides = "collect")
+  }
+
+  list(
+    plot = final_plot,
+    layout = list(
+      strata = list(rows = max_strata_rows, cols = max_strata_cols),
+      responses = resp_layout
+    ),
+    has_strata = has_strata,
+    n_responses = length(response_plots)
+  )
+}


### PR DESCRIPTION
## Summary
- streamline `visualize_server` by delegating layout management and plot building to dedicated helper modules
- add reusable helpers for layout controls and layout synchronization while keeping existing behavior intact
- extract ANOVA plot construction into its own builder to maintain identical patchwork output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f928c320cc832b820de96be8445fb5