### PR TITLE
Add PCA labeling controls and chicken icon styling

### DIFF
--- a/R/module_analysis_pca_helpers.R
+++ b/R/module_analysis_pca_helpers.R
@@ -2,24 +2,35 @@
 # 🧩 PCA Helpers — Biplot Builder
 # ===============================================================
 
-build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL) {
+build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
+                             label_var = NULL, label_size = 2) {
   stopifnot(!is.null(pca_obj$x))
-  
+
   scores <- as.data.frame(pca_obj$x[, 1:2])
   names(scores)[1:2] <- c("PC1", "PC2")
-  
+
   if (!is.null(data) && nrow(data) == nrow(scores)) {
     plot_data <- cbind(scores, data)
   } else {
     plot_data <- scores
   }
-  
+
+  if (!is.null(label_var) && !identical(label_var, "") && !is.null(plot_data[[label_var]])) {
+    plot_data$`..label..` <- as.character(plot_data[[label_var]])
+  } else {
+    label_var <- NULL
+  }
+
   aes_mapping <- aes(x = PC1, y = PC2)
   if (!is.null(color_var)) aes_mapping <- modifyList(aes_mapping, aes(color = .data[[color_var]]))
   if (!is.null(shape_var)) aes_mapping <- modifyList(aes_mapping, aes(shape = .data[[shape_var]]))
-  
-  ggplot(plot_data, aes_mapping) +
-    geom_point(size = 3) +
+
+  g <- ggplot(plot_data, aes_mapping) +
+    geom_point(
+      size = 3,
+      shape = if (is.null(shape_var)) "\U0001F413" else NULL,
+      color = if (is.null(color_var)) "black" else NULL
+    ) +
     theme_minimal(base_size = 14) +
     labs(
       title = "PCA Biplot",
@@ -32,4 +43,18 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL) 
       plot.title = element_text(size = 16, face = "bold"),
       legend.position = "right"
     )
+
+  if (!is.null(label_var)) {
+    g <- g + ggrepel::geom_text_repel(
+      aes(label = `..label..`),
+      size = label_size,
+      max.overlaps = Inf,
+      min.segment.length = 0,
+      box.padding = 0.3,
+      point.padding = 0.2,
+      segment.size = 0.2
+    )
+  }
+
+  g
 }

--- a/R/module_visualize.R
+++ b/R/module_visualize.R
@@ -183,8 +183,19 @@ visualize_server <- function(id, filtered_data, model_fit) {
 
           color_var <- if (!is.null(input$pca_color) && input$pca_color != "None") input$pca_color else NULL
           shape_var <- if (!is.null(input$pca_shape) && input$pca_shape != "None") input$pca_shape else NULL
+          label_var <- if (!is.null(input$pca_label) && input$pca_label != "None") input$pca_label else NULL
+          label_size <- if (!is.null(input$pca_label_size) && !is.na(input$pca_label_size)) input$pca_label_size else 2
 
-          return(build_pca_biplot(pca_obj, info$data, color_var = color_var, shape_var = shape_var))
+          return(
+            build_pca_biplot(
+              pca_obj,
+              info$data,
+              color_var = color_var,
+              shape_var = shape_var,
+              label_var = label_var,
+              label_size = label_size
+            )
+          )
         }
 
       }
@@ -220,8 +231,17 @@ visualize_server <- function(id, filtered_data, model_fit) {
 
             color_var <- if (!is.null(input$pca_color) && input$pca_color != "None") input$pca_color else NULL
             shape_var <- if (!is.null(input$pca_shape) && input$pca_shape != "None") input$pca_shape else NULL
+            label_var <- if (!is.null(input$pca_label) && input$pca_label != "None") input$pca_label else NULL
+            label_size <- if (!is.null(input$pca_label_size) && !is.na(input$pca_label_size)) input$pca_label_size else 2
 
-            g <- build_pca_biplot(pca_obj, info$data, color_var = color_var, shape_var = shape_var)
+            g <- build_pca_biplot(
+              pca_obj,
+              info$data,
+              color_var = color_var,
+              shape_var = shape_var,
+              label_var = label_var,
+              label_size = label_size
+            )
           }
         }
 

--- a/R/module_visualize_helpers.R
+++ b/R/module_visualize_helpers.R
@@ -87,6 +87,7 @@ build_pca_layout_controls <- function(ns, data) {
   if (is.null(data)) return(NULL)
   
   cat_vars <- names(data)[sapply(data, function(x) is.factor(x) || is.character(x))]
+  all_vars <- names(data)
   
   tagList(
     h4("PCA Plot Controls"),
@@ -97,7 +98,9 @@ build_pca_layout_controls <- function(ns, data) {
       )
     } else {
       helpText("No categorical variables available for coloring or shaping.")
-    }
+    },
+    selectInput(ns("pca_label"), "Label points with:", choices = c("None", all_vars), selected = "None"),
+    sliderInput(ns("pca_label_size"), "Label size", min = 1, max = 5, step = 0.2, value = 2)
   )
 }
 


### PR DESCRIPTION
## Summary
- add PCA visualization controls to label PCA scores and adjust label size
- update the PCA biplot builder to use a chicken icon by default and support ggrepel text labels
- pass the new options through the visualization server and download handler

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f92ef36ff8832bbbc6806ccd20d256