### PR TITLE
Add descriptive statistics visualization support

### DIFF
--- a/R/module_analysis_descriptive_helpers.R
+++ b/R/module_analysis_descriptive_helpers.R
@@ -8,7 +8,7 @@ library(skimr)
 # ---- Main computation wrapper ----
 compute_descriptive_summary <- function(data, group_var = NULL) {
   numeric_vars <- names(data)[sapply(data, is.numeric)]
-  
+
   group_data <- if (!is.null(group_var)) group_by(data, .data[[group_var]]) else data
   
   skim_out <- if (!is.null(group_var)) {
@@ -49,12 +49,26 @@ compute_descriptive_summary <- function(data, group_var = NULL) {
       .names = "shapiro_{.col}"
     ), .groups = "drop")
   
+  selected_cols <- numeric_vars
+  if (!is.null(group_var)) {
+    selected_cols <- unique(c(group_var, numeric_vars))
+  }
+
+  plot_data <- if (length(selected_cols) > 0) {
+    as.data.frame(data[, selected_cols, drop = FALSE])
+  } else {
+    NULL
+  }
+
   list(
     skim = skim_out,
     cv = cv_out,
     outliers = outlier_out,
     missing = missing_out,
-    shapiro = shapiro_out
+    shapiro = shapiro_out,
+    group_var = group_var,
+    numeric_vars = numeric_vars,
+    data_for_plots = plot_data
   )
 }
 

--- a/R/module_visualize.R
+++ b/R/module_visualize.R
@@ -118,19 +118,28 @@ visualize_server <- function(id, filtered_data, model_fit) {
 
     plot_obj_info <- reactive({
       info <- model_info()
-      if (is.null(info) || is.null(info$models) || length(info$models) == 0) {
+      if (is.null(info)) {
         return(NULL)
       }
 
       current_type <- if (!is.null(info$type)) info$type else "anova"
-      if (!identical(current_type, "anova")) {
-        return(NULL)
+
+      if (identical(current_type, "descriptive")) {
+        return(build_descriptive_plot_info(info, layout_state$effective_input))
       }
 
-      data <- df()
-      req(data)
+      if (identical(current_type, "anova")) {
+        if (is.null(info$models) || length(info$models) == 0) {
+          return(NULL)
+        }
 
-      build_anova_plot_info(data, info, layout_state$effective_input)
+        data <- df()
+        req(data)
+
+        return(build_anova_plot_info(data, info, layout_state$effective_input))
+      }
+
+      NULL
     })
 
     observe_layout_synchronization(plot_obj_info, layout_state, session)
@@ -198,10 +207,27 @@ visualize_server <- function(id, filtered_data, model_fit) {
           )
         }
 
+        if (info$type == "descriptive") {
+          plot_data <- info$data_for_plots
+          validate(need(!is.null(plot_data), "Run Descriptive Statistics to generate plots."))
+          validate(need(nrow(plot_data) > 0, "Filtered data has no rows to plot."))
+          numeric_vars <- info$numeric_vars
+          if (is.null(numeric_vars)) numeric_vars <- character(0)
+          validate(need(length(numeric_vars) > 0, "No numeric variables available for plotting."))
+        }
       }
 
-      req(plot_obj())
-      plot_obj()
+      plot_val <- plot_obj()
+
+      if (is.null(plot_val)) {
+        if (!is.null(info$type) && info$type == "descriptive") {
+          validate(need(FALSE, "No valid numeric data available for plotting."))
+        } else {
+          validate(need(FALSE, "Run the selected analysis to generate plots."))
+        }
+      }
+
+      plot_val
 
     },
     width = function() plot_size()$w,

--- a/R/module_visualize_helpers.R
+++ b/R/module_visualize_helpers.R
@@ -85,10 +85,10 @@ build_ggpairs_layout_controls <- function() {
 # ---- 3. PCA layout controls ----
 build_pca_layout_controls <- function(ns, data) {
   if (is.null(data)) return(NULL)
-  
+
   cat_vars <- names(data)[sapply(data, function(x) is.factor(x) || is.character(x))]
   all_vars <- names(data)
-  
+
   tagList(
     h4("PCA Plot Controls"),
     if (length(cat_vars) > 0) {
@@ -101,6 +101,56 @@ build_pca_layout_controls <- function(ns, data) {
     },
     selectInput(ns("pca_label"), "Label points with:", choices = c("None", all_vars), selected = "None"),
     sliderInput(ns("pca_label_size"), "Label size", min = 1, max = 5, step = 0.2, value = 2)
+  )
+}
+
+# ---- 4. Descriptive layout controls ----
+build_descriptive_layout_controls <- function(ns, input, info, default_ui_value) {
+  n_responses <- if (!is.null(info$numeric_vars)) length(info$numeric_vars) else 0
+
+  base_ui <- tagList(
+    h4("Layout Controls"),
+    helpText("Arrange the histograms or boxplots generated for each numeric variable.")
+  )
+
+  if (n_responses <= 0) {
+    return(tagList(
+      base_ui,
+      helpText("Run the descriptive statistics to enable plotting controls.")
+    ))
+  }
+
+  if (n_responses == 1) {
+    return(tagList(
+      base_ui,
+      helpText("Only one numeric variable available; grid controls are hidden.")
+    ))
+  }
+
+  tagList(
+    base_ui,
+    fluidRow(
+      column(
+        width = 6,
+        numericInput(
+          ns("resp_rows"),
+          "Grid rows",
+          value = isolate(default_ui_value(input$resp_rows)),
+          min = 0,
+          step = 1
+        )
+      ),
+      column(
+        width = 6,
+        numericInput(
+          ns("resp_cols"),
+          "Grid columns",
+          value = isolate(default_ui_value(input$resp_cols)),
+          min = 0,
+          step = 1
+        )
+      )
+    )
   )
 }
 
@@ -157,6 +207,10 @@ build_layout_controls_for_type <- function(ns, input, info, default_ui_value, da
 
   if (identical(current_type, "pca")) {
     return(build_pca_layout_controls(ns, data_for_pca))
+  }
+
+  if (identical(current_type, "descriptive")) {
+    return(build_descriptive_layout_controls(ns, input, info, default_ui_value))
   }
 
   NULL

--- a/R/module_visualize_plot_builders.R
+++ b/R/module_visualize_plot_builders.R
@@ -190,3 +190,75 @@ build_anova_plot_info <- function(data, info, effective_input) {
     n_responses = length(response_plots)
   )
 }
+
+build_descriptive_plot_info <- function(info, effective_input) {
+  data <- info$data_for_plots
+  if (is.null(data)) {
+    return(NULL)
+  }
+
+  numeric_vars <- info$numeric_vars
+  if (is.null(numeric_vars) || length(numeric_vars) == 0) {
+    return(NULL)
+  }
+
+  group_var <- info$group_var
+
+  plot_list <- list()
+
+  for (var in numeric_vars) {
+    if (!var %in% names(data)) next
+
+    df_var <- data[, c(group_var, var), drop = FALSE]
+    df_var <- df_var[!is.na(df_var[[var]]), , drop = FALSE]
+
+    if (nrow(df_var) == 0) {
+      next
+    }
+
+    p <- if (is.null(group_var)) {
+      bins <- min(30, max(10, floor(sqrt(nrow(df_var)))))
+      ggplot(df_var, aes_string(x = var)) +
+        geom_histogram(fill = "steelblue", color = "white", bins = bins) +
+        theme_minimal(base_size = 14) +
+        labs(x = var, y = "Count")
+    } else {
+      df_var[[group_var]] <- as.factor(df_var[[group_var]])
+      ggplot(df_var, aes_string(x = group_var, y = var, fill = group_var)) +
+        geom_boxplot(alpha = 0.75, outlier.shape = 16, outlier.size = 2) +
+        theme_minimal(base_size = 14) +
+        labs(x = group_var, y = var, fill = group_var) +
+        theme(legend.position = "none")
+    }
+
+    plot_list[[var]] <- p +
+      ggtitle(var) +
+      theme(plot.title = element_text(size = 12, face = "bold"))
+  }
+
+  if (length(plot_list) == 0) {
+    return(NULL)
+  }
+
+  layout <- compute_layout(
+    length(plot_list),
+    effective_input("resp_rows"),
+    effective_input("resp_cols")
+  )
+
+  combined <- patchwork::wrap_plots(
+    plotlist = plot_list,
+    nrow = layout$nrow,
+    ncol = layout$ncol
+  )
+
+  list(
+    plot = combined,
+    layout = list(
+      strata = list(rows = 1, cols = 1),
+      responses = layout
+    ),
+    has_strata = FALSE,
+    n_responses = length(plot_list)
+  )
+}


### PR DESCRIPTION
## Summary
- include plotting metadata in descriptive statistics summaries so downstream modules can build charts
- add histogram/boxplot builder and layout controls for descriptive outputs in the visualization step
- handle validation messaging when descriptive plots are unavailable or data are missing

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f935e9836c832b99c4bba6435c5374