### PR TITLE
Refactor descriptive plots builder into focused helpers

### DIFF
--- a/R/module_visualize_descriptive.R
+++ b/R/module_visualize_descriptive.R
@@ -98,15 +98,16 @@ visualize_descriptive_server <- function(id, descriptive_summary, filtered_data)
       plots <- plots_all()
       validate(need(!is.null(plots), "No plots available."))
       
+      metrics <- plots$metrics
       switch(
         input$plot_type,
         categorical = plots$factors,
         boxplots = plots$boxplots,
         histograms = plots$histograms,
-        cv = if (!is.null(plots$metrics)) plots$metrics[[1]] else NULL,
-        outliers = if (!is.null(plots$metrics)) plots$metrics[[2]] else NULL,
-        missing = if (!is.null(plots$metrics)) plots$metrics[[3]] else NULL,
-        shapiro = if (!is.null(plots$metrics)) plots$metrics[[4]] else NULL,
+        cv = if (!is.null(metrics)) metrics$cv else NULL,
+        outliers = if (!is.null(metrics)) metrics$outliers else NULL,
+        missing = if (!is.null(metrics)) metrics$missing else NULL,
+        shapiro = if (!is.null(metrics)) metrics$shapiro else NULL,
         NULL
       )
     })


### PR DESCRIPTION
## Summary
- break the descriptive plot builder into focused helper functions for metrics and distributions
- adjust the descriptive visualization module to use the new helper outputs when switching plot types

## Testing
- Not Run (Rscript not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fa52b25fec832b89972ff1496761cc