### PR TITLE
Align two-way ANOVA color controls with one-way widget

### DIFF
--- a/R/custom_widgets.R
+++ b/R/custom_widgets.R
@@ -11,7 +11,10 @@ basic_color_palette <- c(
 )
 
 # ---- UI Helper ----
-color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_palette, ncol = 4) {
+color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_palette,
+                                 ncol = 4, selected = NULL) {
+  selected_color <- if (is.null(selected)) palette[1] else selected
+
   tagList(
     tags$style(HTML(sprintf("
       .color-dropdown {
@@ -25,7 +28,6 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
         height: 32px;
         border: 1px solid #ccc;
         border-radius: 4px;
-        background-color: steelblue;
         cursor: pointer;
       }
       .color-dropdown-grid {
@@ -56,7 +58,8 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
       class = "color-dropdown",
       tags$div(
         id = ns(paste0(id, "_button")),
-        class = "color-dropdown-button"
+        class = "color-dropdown-button",
+        style = sprintf("background-color:%s;", selected_color)
       ),
       tags$div(
         id = ns(paste0(id, "_grid")),
@@ -85,6 +88,7 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
       $(document).on('click', function(){
         $('.color-dropdown-grid').hide();
       });
-    ", ns(id), ns(id))))
+      Shiny.setInputValue('%s','%s',{priority:'event'});
+    ", ns(id), ns(id), ns(id), selected_color)))
   )
 }

--- a/R/module_colors.R
+++ b/R/module_colors.R
@@ -34,9 +34,15 @@ add_color_customization_server <- function(ns, input, output, data, color_var_re
       req(color_var)
       
       lvls <- levels(as.factor(data()[[color_var]]))
-      cols <- sapply(seq_along(lvls), function(i) {
-        input[[paste0("col_", color_var, "_", i)]]
-      })
+      base_palette <- RColorBrewer::brewer.pal(8, "Set2")
+      cols <- vapply(seq_along(lvls), function(i) {
+        input_val <- input[[paste0("col_", color_var, "_", i)]]
+        if (is.null(input_val) || identical(input_val, "")) {
+          base_palette[(i - 1) %% length(base_palette) + 1]
+        } else {
+          input_val
+        }
+      }, character(1))
       names(cols) <- lvls
       cols
     } else {

--- a/R/module_colors_helpers.R
+++ b/R/module_colors_helpers.R
@@ -9,14 +9,22 @@ render_color_inputs <- function(ns, data, color_var) {
   values <- data()[[color_var]]
   lvls <- if (is.factor(values)) levels(values) else unique(as.character(values))
   lvls <- lvls[!is.na(lvls)]
-  
+  default_palette <- RColorBrewer::brewer.pal(8, "Set2")
+
   tagList(
     h5(paste("Customize colors for", color_var)),
     lapply(seq_along(lvls), function(i) {
-      colourpicker::colourInput(
-        ns(paste0("col_", color_var, "_", i)),
-        label = lvls[i],
-        value = RColorBrewer::brewer.pal(8, "Set2")[i %% 8 + 1]
+      selected <- default_palette[(i - 1) %% length(default_palette) + 1]
+      tags$div(
+        style = "margin-bottom: 8px;",
+        tags$label(lvls[i]),
+        color_dropdown_input(
+          ns,
+          id = paste0("col_", color_var, "_", i),
+          palette = basic_color_palette,
+          ncol = 4,
+          selected = selected
+        )
       )
     })
   )


### PR DESCRIPTION
## Summary
- wire the two-way ANOVA mean ± SE plot through the shared color customization module so custom palettes are used everywhere
- update the compact color dropdown widget to accept default selections and pre-populate Shiny inputs
- reuse the dropdown palette UI for multi-group color controls with sensible defaults

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff88cc830c832ba4bd548d2b7e8d13