### PR TITLE
Guard descriptive plot type selection and prevent layout sync loops

### DIFF
--- a/R/descriptive_visualize.R
+++ b/R/descriptive_visualize.R
@@ -25,21 +25,30 @@ visualize_descriptive_ui <- function(id) {
         selected = "boxplots"
       ),
       hr(),
-      numericInput(
-        ns("plot_width"),
-        label = "Plot width (px)",
-        value = 800,
-        min = 400,
-        max = 2000,
-        step = 100
-      ),
-      numericInput(
-        ns("plot_height"),
-        label = "Plot height (px)",
-        value = 600,
-        min = 400,
-        max = 2000,
-        step = 100
+      uiOutput(ns("layout_controls")),
+      fluidRow(
+        column(
+          6,
+          numericInput(
+            ns("plot_width"),
+            label = "Subplot width (px)",
+            value = 400,
+            min = 200,
+            max = 2000,
+            step = 50
+          )
+        ),
+        column(
+          6,
+          numericInput(
+            ns("plot_height"),
+            label = "Subplot height (px)",
+            value = 300,
+            min = 200,
+            max = 2000,
+            step = 50
+          )
+        )
       ),
       hr(),
       downloadButton(ns("download_plot"), "Download Plot")
@@ -47,7 +56,7 @@ visualize_descriptive_ui <- function(id) {
     mainPanel(
       width = 8,
       h4("Descriptive Visualization"),
-      plotOutput(ns("plot"))
+      plotOutput(ns("plot"), height = "auto")
     )
   )
 }
@@ -72,45 +81,49 @@ visualize_descriptive_server <- function(id, filtered_data, descriptive_summary)
       info
     })
     
-    plot_size <- reactive({
-      w <- suppressWarnings(as.numeric(input$plot_width))
-      h <- suppressWarnings(as.numeric(input$plot_height))
-      list(
-        w = ifelse(is.na(w) || w <= 0, 800, w),
-        h = ifelse(is.na(h) || h <= 0, 600, h)
-      )
-    })
+    layout_state <- initialize_layout_state(input, session)
     
     # ------------------------------------------------------------
     # 2️⃣ Build all plots using the shared helper
     # ------------------------------------------------------------
     plots_all <- reactive({
       info <- summary_info()
-      
+
       summary_data <- info$summary
       if (is.reactive(summary_data)) summary_data <- summary_data()
-      
+
       selected_vars <- info$selected_vars
       if (is.reactive(selected_vars)) selected_vars <- selected_vars()
-      
+
       data_subset <- df()
       if (!is.null(selected_vars)) {
         data_subset <- data_subset[, intersect(names(data_subset), selected_vars), drop = FALSE]
       }
-      
-      build_descriptive_plots(summary_data, data_subset)
+
+      layout_overrides <- list(
+        rows = layout_state$effective_input("resp_rows"),
+        cols = layout_state$effective_input("resp_cols")
+      )
+
+      build_descriptive_plots(summary_data, data_subset, layout_overrides)
     })
-    
+
     # ------------------------------------------------------------
     # 3️⃣ Pick correct plot based on selection
     # ------------------------------------------------------------
     build_current_plot <- reactive({
       plots <- plots_all()
       validate(need(!is.null(plots), "No plots available."))
-      
+
+      req(!is.null(input$plot_type))
+
+      plot_choice <- as.character(input$plot_type)
+      validate(need(length(plot_choice) == 1, "Select a single plot type."))
+      plot_choice <- plot_choice[[1]]
+
       metrics <- plots$metrics
-      switch(
-        input$plot_type,
+      entry <- switch(
+        plot_choice,
         categorical = plots$factors,
         boxplots = plots$boxplots,
         histograms = plots$histograms,
@@ -120,16 +133,101 @@ visualize_descriptive_server <- function(id, filtered_data, descriptive_summary)
         shapiro = if (!is.null(metrics)) metrics$shapiro else NULL,
         NULL
       )
+
+      entry
     })
-    
+
+    plot_entry <- reactive({
+      entry <- build_current_plot()
+      if (is.null(entry)) return(NULL)
+
+      if (!is.list(entry) || is.null(entry$plot)) {
+        return(list(
+          plot = entry,
+          panels = 1L,
+          layout = list(rows = 1L, cols = 1L)
+        ))
+      }
+
+      entry
+    })
+
+    plot_size <- reactive({
+      entry <- plot_entry()
+
+      w <- suppressWarnings(as.numeric(input$plot_width))
+      h <- suppressWarnings(as.numeric(input$plot_height))
+
+      subplot_w <- ifelse(is.na(w) || w <= 0, 400, w)
+      subplot_h <- ifelse(is.na(h) || h <= 0, 300, h)
+
+      if (is.null(entry) || is.null(entry$layout)) {
+        return(list(w = subplot_w, h = subplot_h))
+      }
+
+      list(
+        w = subplot_w * max(1, entry$layout$cols),
+        h = subplot_h * max(1, entry$layout$rows)
+      )
+    })
+
+    output$layout_controls <- renderUI({
+      entry <- plot_entry()
+      if (is.null(entry) || is.null(entry$panels) || entry$panels <= 1) {
+        return(NULL)
+      }
+
+      tagList(
+        h4("Layout Controls"),
+        fluidRow(
+          column(
+            width = 6,
+            numericInput(
+              session$ns("resp_rows"),
+              "Grid rows",
+              value = isolate(layout_state$default_ui_value(input$resp_rows)),
+              min = 0,
+              step = 1
+            )
+          ),
+          column(
+            width = 6,
+            numericInput(
+              session$ns("resp_cols"),
+              "Grid columns",
+              value = isolate(layout_state$default_ui_value(input$resp_cols)),
+              min = 0,
+              step = 1
+            )
+          )
+        )
+      )
+    })
+
+    layout_info <- reactive({
+      entry <- plot_entry()
+      if (is.null(entry)) return(NULL)
+
+      list(
+        has_strata = FALSE,
+        layout = list(
+          strata = list(rows = 1L, cols = 1L),
+          responses = list(nrow = entry$layout$rows, ncol = entry$layout$cols)
+        ),
+        n_responses = entry$panels
+      )
+    })
+
+    observe_layout_synchronization(layout_info, layout_state, session)
+
     # ------------------------------------------------------------
     # 4️⃣ Render plot safely
     # ------------------------------------------------------------
     output$plot <- renderPlot({
-      p <- build_current_plot()
-      validate(need(!is.null(p), "Selected plot not available."))
+      entry <- plot_entry()
+      validate(need(!is.null(entry), "Selected plot not available."))
       # patchwork objects are fine with print()
-      print(p)
+      print(entry$plot)
     },
     width = function() plot_size()$w,
     height = function() plot_size()$h,
@@ -141,13 +239,13 @@ visualize_descriptive_server <- function(id, filtered_data, descriptive_summary)
     output$download_plot <- downloadHandler(
       filename = function() paste0("descriptive_plot_", Sys.Date(), ".png"),
       content = function(file) {
-        p <- build_current_plot()
-        validate(need(!is.null(p), "No plot available to download."))
-        
+        entry <- plot_entry()
+        validate(need(!is.null(entry), "No plot available to download."))
+
         size <- plot_size()
         ggsave(
           filename = file,
-          plot = p,
+          plot = entry$plot,
           device = "png",
           dpi = 300,
           width = size$w / 96,

--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -67,11 +67,28 @@ observe_layout_synchronization <- function(plot_info_reactive, layout_state, ses
     if (is.null(info)) return()
 
     sync_input <- function(id, value, manual_key) {
-      val <- ifelse(is.null(value) || value <= 0, 1, value)
-      if (!isTRUE(layout_state$manual[[manual_key]])) {
-        layout_state$suppress[[id]] <- TRUE
-        updateNumericInput(session, id, value = val)
+      if (isTRUE(layout_state$manual[[manual_key]])) {
+        return()
       }
+
+      val <- suppressWarnings(as.numeric(value))
+      if (is.na(val) || val <= 0) {
+        val <- 1L
+      } else {
+        val <- as.integer(round(val))
+      }
+
+      current <- isolate({
+        cur <- suppressWarnings(as.numeric(input[[id]]))
+        if (length(cur) == 0) NA_real_ else cur
+      })
+
+      if (!is.na(current) && identical(as.integer(round(current)), val)) {
+        return()
+      }
+
+      layout_state$suppress[[id]] <- TRUE
+      updateNumericInput(session, id, value = val)
     }
 
     if (isTRUE(info$has_strata)) {

--- a/R/module_visualize_plot_builders.R
+++ b/R/module_visualize_plot_builders.R
@@ -2,7 +2,7 @@
 # 🎨 Visualization Plot Builders
 # ===============================================================
 
-build_descriptive_plots <- function(summary_info, original_data = NULL) {
+build_descriptive_plots <- function(summary_info, original_data = NULL, layout_overrides = NULL) {
   summary_data <- resolve_summary_input(summary_info)
 
   plots <- list()
@@ -13,17 +13,17 @@ build_descriptive_plots <- function(summary_info, original_data = NULL) {
   }
 
   if (!is.null(original_data)) {
-    factor_plot <- build_descriptive_categorical_plot(original_data)
+    factor_plot <- build_descriptive_categorical_plot(original_data, layout_overrides)
     if (!is.null(factor_plot)) {
       plots$factors <- factor_plot
     }
 
-    box_plot <- build_descriptive_boxplot(original_data)
+    box_plot <- build_descriptive_boxplot(original_data, layout_overrides)
     if (!is.null(box_plot)) {
       plots$boxplots <- box_plot
     }
 
-    hist_plot <- build_descriptive_histogram(original_data)
+    hist_plot <- build_descriptive_histogram(original_data, layout_overrides)
     if (!is.null(hist_plot)) {
       plots$histograms <- hist_plot
     }
@@ -41,6 +41,24 @@ resolve_summary_input <- function(summary_info) {
     return(summary_info())
   }
   summary_info
+}
+
+
+descriptive_plot_entry <- function(plot, panels = 1L, layout = list(rows = 1L, cols = 1L)) {
+  rows <- layout$rows
+  cols <- layout$cols
+
+  if (is.null(rows) || is.na(rows) || rows <= 0) rows <- 1L
+  if (is.null(cols) || is.na(cols) || cols <= 0) cols <- 1L
+
+  list(
+    plot = plot,
+    panels = max(1L, as.integer(panels)),
+    layout = list(
+      rows = max(1L, as.integer(rows)),
+      cols = max(1L, as.integer(cols))
+    )
+  )
 }
 
 
@@ -63,7 +81,11 @@ build_descriptive_metric_panel <- function(df, prefix, y_label) {
   if (is.null(tidy)) return(NULL)
 
   plot <- build_descriptive_metric_bar_plot(tidy, y_label)
-  plot + ggtitle(paste("Summary Metric:", y_label))
+  descriptive_plot_entry(
+    plot + ggtitle(paste("Summary Metric:", y_label)),
+    panels = 1L,
+    layout = list(rows = 1L, cols = 1L)
+  )
 }
 
 
@@ -116,7 +138,7 @@ build_descriptive_metric_bar_plot <- function(info, y_label) {
 }
 
 
-build_descriptive_categorical_plot <- function(df) {
+build_descriptive_categorical_plot <- function(df, layout_overrides = NULL) {
   factor_vars <- names(df)[sapply(df, function(x) is.character(x) || is.factor(x))]
   if (length(factor_vars) == 0) return(NULL)
   plots <- lapply(factor_vars, function(v) {
@@ -126,15 +148,18 @@ build_descriptive_categorical_plot <- function(df) {
       labs(title = v, x = NULL, y = "Count") +
       theme(axis.text.x = element_text(angle = 45, hjust = 1))
   })
-  patchwork::wrap_plots(plots, ncol = 2) +
+  layout <- compute_descriptive_layout(length(plots), layout_overrides)
+  combined <- patchwork::wrap_plots(plots, ncol = layout$cols, nrow = layout$rows) +
     patchwork::plot_annotation(
       title = "Categorical Distributions",
       theme = theme(plot.title = element_text(size = 16, face = "bold"))
     )
+
+  descriptive_plot_entry(combined, panels = length(plots), layout = layout)
 }
 
 
-build_descriptive_boxplot <- function(df) {
+build_descriptive_boxplot <- function(df, layout_overrides = NULL) {
   num_vars <- names(df)[sapply(df, is.numeric)]
   if (length(num_vars) == 0) return(NULL)
   plots <- lapply(num_vars, function(v) {
@@ -148,15 +173,18 @@ build_descriptive_boxplot <- function(df) {
         axis.ticks.x = element_blank()
       )
   })
-  patchwork::wrap_plots(plots, ncol = 2) +
+  layout <- compute_descriptive_layout(length(plots), layout_overrides)
+  combined <- patchwork::wrap_plots(plots, ncol = layout$cols, nrow = layout$rows) +
     patchwork::plot_annotation(
       title = "Boxplots",
       theme = theme(plot.title = element_text(size = 16, face = "bold"))
     )
+
+  descriptive_plot_entry(combined, panels = length(plots), layout = layout)
 }
 
 
-build_descriptive_histogram <- function(df) {
+build_descriptive_histogram <- function(df, layout_overrides = NULL) {
   num_vars <- names(df)[sapply(df, is.numeric)]
   if (length(num_vars) == 0) return(NULL)
   plots <- lapply(num_vars, function(v) {
@@ -165,11 +193,23 @@ build_descriptive_histogram <- function(df) {
       theme_minimal(base_size = 13) +
       labs(title = paste(v, "Distribution"), x = NULL, y = "Frequency")
   })
-  patchwork::wrap_plots(plots, ncol = 2) +
+  layout <- compute_descriptive_layout(length(plots), layout_overrides)
+  combined <- patchwork::wrap_plots(plots, ncol = layout$cols, nrow = layout$rows) +
     patchwork::plot_annotation(
       title = "Histograms",
       theme = theme(plot.title = element_text(size = 16, face = "bold"))
     )
+
+  descriptive_plot_entry(combined, panels = length(plots), layout = layout)
+}
+
+
+compute_descriptive_layout <- function(n_panels, layout_overrides = NULL) {
+  rows_input <- if (!is.null(layout_overrides)) layout_overrides$rows else 0
+  cols_input <- if (!is.null(layout_overrides)) layout_overrides$cols else 0
+
+  grid <- compute_grid_layout(n_panels, rows_input, cols_input)
+  list(rows = grid$nrow, cols = grid$ncol)
 }
 
 


### PR DESCRIPTION
## Summary
- ensure the descriptive visualization server waits for a single plot type selection before dispatching the plot switch
- coerce the selected plot type to a scalar string so Shiny never passes an invalid value into switch
- stop the layout synchronization helper from repeatedly updating descriptive grid inputs when they already match the plot layout

## Testing
- Not Run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff9087a8e8832b84593c65e383c23c