### PR TITLE
Fix stratified categorical barplots

### DIFF
--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -62,7 +62,7 @@ descriptive_server <- function(id, filtered_data) {
       local_data <- df()  # create a copy to avoid modifying shared reactive
       selected_vars <- unique(c(input$cat_vars, input$num_vars))
       validate(need(length(selected_vars) > 0, "Please select at least one variable."))
-      
+
       group_var <- if (is.null(input$stratify_var) || input$stratify_var == "None") NULL else input$stratify_var
       if (!is.null(group_var)) {
         # make sure the group var is present
@@ -81,20 +81,28 @@ descriptive_server <- function(id, filtered_data) {
         }
         local_data <- droplevels(local_data)
       }
-      
+
       local_data <- local_data[, selected_vars, drop = FALSE]
-      
+
       if (!is.null(group_var) && !is.null(input$strata_order)) {
         if (group_var %in% names(local_data)) {
           local_data[[group_var]] <- factor(as.character(local_data[[group_var]]),
                                             levels = input$strata_order)
         }
       }
-      
+
+      strata_levels <- if (!is.null(group_var) && group_var %in% names(local_data)) {
+        levels(local_data[[group_var]])
+      } else {
+        NULL
+      }
+
       list(
         summary = compute_descriptive_summary(local_data, group_var),
         selected_vars = selected_vars,
-        group_var = group_var
+        group_var = group_var,
+        processed_data = local_data,
+        strata_levels = strata_levels
       )
     })
     
@@ -129,7 +137,9 @@ descriptive_server <- function(id, filtered_data) {
         data = df,
         summary = reactive(summary_data()$summary),
         selected_vars = reactive(summary_data()$selected_vars),
-        group_var = reactive(summary_data()$group_var)
+        group_var = reactive(summary_data()$group_var),
+        processed_data = reactive(summary_data()$processed_data),
+        strata_levels = reactive(summary_data()$strata_levels)
       )
     }))
     

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -39,19 +39,24 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
     })
     
     plot_info <- reactive({
-      dat <- filtered_data()
       info <- summary_info()
-      
-      validate(need(!is.null(dat) && is.data.frame(dat) && nrow(dat) > 0, "No data available."))
+
       validate(need(!is.null(info), "Summary not available."))
-      
+
+      processed <- resolve_input_value(info$processed_data)
+      dat <- if (!is.null(processed)) processed else filtered_data()
+
+      validate(need(!is.null(dat) && is.data.frame(dat) && nrow(dat) > 0, "No data available."))
+
       selected_vars <- resolve_input_value(info$selected_vars)
       group_var     <- resolve_input_value(info$group_var)
-      
+      strata_levels <- resolve_input_value(info$strata_levels)
+
       out <- build_descriptive_categorical_plot(
         df = dat,
         selected_vars = selected_vars,
         group_var = group_var,
+        strata_levels = strata_levels,
         show_proportions = isTRUE(input$show_proportions),
         nrow_input = input$n_rows,
         ncol_input = input$n_cols

--- a/R/module_visualize_plot_builders.R
+++ b/R/module_visualize_plot_builders.R
@@ -119,6 +119,7 @@ build_descriptive_metric_bar_plot <- function(info, y_label) {
 build_descriptive_categorical_plot <- function(df,
                                                selected_vars = NULL,
                                                group_var = NULL,
+                                               strata_levels = NULL,
                                                show_proportions = FALSE,
                                                nrow_input = NULL,
                                                ncol_input = NULL) {
@@ -136,13 +137,22 @@ build_descriptive_categorical_plot <- function(df,
   if (!is.null(group_var) && group_var %in% names(df)) {
     df[[group_var]] <- as.character(df[[group_var]])
     df[[group_var]][is.na(df[[group_var]]) | trimws(df[[group_var]]) == ""] <- "Missing"
-    df[[group_var]] <- factor(df[[group_var]], levels = unique(df[[group_var]]))
+
+    if (!is.null(strata_levels) && length(strata_levels) > 0) {
+      keep_levels <- unique(strata_levels)
+      df <- df[df[[group_var]] %in% keep_levels, , drop = FALSE]
+      if (nrow(df) == 0) return(NULL)
+      df[[group_var]] <- factor(df[[group_var]], levels = keep_levels)
+    } else {
+      df[[group_var]] <- factor(df[[group_var]], levels = unique(df[[group_var]]))
+    }
   } else {
     group_var <- NULL
   }
-  
+
   plots <- lapply(factor_vars, function(var) {
-    cols_to_use <- c(var, group_var)
+    group_col <- if (!is.null(group_var) && !identical(group_var, var)) group_var else NULL
+    cols_to_use <- c(var, group_col)
     cols_to_use <- cols_to_use[cols_to_use %in% names(df)]
     var_data <- df[, cols_to_use, drop = FALSE]
     
@@ -160,14 +170,14 @@ build_descriptive_categorical_plot <- function(df,
     
     y_label <- if (isTRUE(show_proportions)) "Proportion" else "Count"
     
-    if (!is.null(group_var)) {
-      var_data[[group_var]] <- droplevels(var_data[[group_var]])
-      count_df <- dplyr::count(var_data, .data[[var]], .data[[group_var]], name = "count")
+    if (!is.null(group_col)) {
+      var_data[[group_col]] <- droplevels(var_data[[group_col]])
+      count_df <- dplyr::count(var_data, .data[[var]], .data[[group_col]], name = "count")
       if (nrow(count_df) == 0) return(NULL)
-      
+
       if (isTRUE(show_proportions)) {
         count_df <- count_df |>
-          dplyr::group_by(.data[[group_var]]) |>
+          dplyr::group_by(.data[[group_col]]) |>
           dplyr::mutate(total = sum(.data$count, na.rm = TRUE)) |>
           dplyr::mutate(value = ifelse(.data$total > 0, .data$count / .data$total, 0)) |>
           dplyr::ungroup()
@@ -175,19 +185,19 @@ build_descriptive_categorical_plot <- function(df,
       } else {
         count_df <- dplyr::mutate(count_df, value = .data$count)
       }
-      
+
       count_df[[var]] <- factor(as.character(count_df[[var]]), levels = level_order)
-      
-      p <- ggplot(count_df, aes(x = .data[[var]], y = .data$value, fill = .data[[group_var]])) +
+
+      p <- ggplot(count_df, aes(x = .data[[var]], y = .data$value, fill = .data[[group_col]])) +
         geom_col(position = position_dodge(width = 0.75), width = 0.65) +
         theme_minimal(base_size = 13) +
-        labs(title = var, x = NULL, y = y_label, fill = group_var) +
+        labs(title = var, x = NULL, y = y_label, fill = group_col) +
         theme(axis.text.x = element_text(angle = 45, hjust = 1))
-      
+
       if (isTRUE(show_proportions)) {
         p <- p + scale_y_continuous(labels = scales::percent_format(accuracy = 1), limits = c(0, 1))
       }
-      
+
       p
     } else {
       count_df <- dplyr::count(var_data, .data[[var]], name = "count")


### PR DESCRIPTION
## Summary
- pass the processed descriptive dataset and selected strata levels through the summary payload
- adjust categorical barplot rendering to honour the chosen stratification order and skip duplicate grouping columns

## Testing
- Rscript -e "source('R/module_visualize_plot_builders.R')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69009c62f484832bac12a423b5b5a29e