### PR TITLE
Clamp grid controls to rendered layout

### DIFF
--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -60,12 +60,43 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
       
       validate(need(!is.null(out), "No numeric variables available for plotting."))
       
-      # Derive safe maxima for the inputs WITHOUT changing their values
+      # Derive safe maxima and gently clamp control values so the visible
+      # settings always match the rendered layout (removing the grid flicker).
       n_panels <- out$panels
       max_val  <- max(1, as.integer(n_panels))
+
+      layout_info <- out$layout
+      if (is.null(layout_info) || !is.list(layout_info)) {
+        layout_info <- list()
+      }
+
+      safe_rows <- layout_info$nrow
+      safe_cols <- layout_info$ncol
+
+      if (is.null(safe_rows) || !is.finite(safe_rows)) safe_rows <- max_val
+      if (is.null(safe_cols) || !is.finite(safe_cols)) safe_cols <- max_val
+
+      safe_rows <- min(max(1L, as.integer(safe_rows)), max_val)
+      safe_cols <- min(max(1L, as.integer(safe_cols)), max_val)
+
+      current_rows <- suppressWarnings(as.integer(input$n_rows))
+      current_cols <- suppressWarnings(as.integer(input$n_cols))
+
+      if (length(current_rows) == 0 || is.na(current_rows)) current_rows <- NULL
+      if (length(current_cols) == 0 || is.na(current_cols)) current_cols <- NULL
+
       isolate({
-        updateNumericInput(session, "n_rows", max = max_val)
-        updateNumericInput(session, "n_cols", max = max_val)
+        if (!identical(current_rows, safe_rows)) {
+          updateNumericInput(session, "n_rows", value = safe_rows, max = max_val)
+        } else {
+          updateNumericInput(session, "n_rows", max = max_val)
+        }
+
+        if (!identical(current_cols, safe_cols)) {
+          updateNumericInput(session, "n_cols", value = safe_cols, max = max_val)
+        } else {
+          updateNumericInput(session, "n_cols", max = max_val)
+        }
       })
       
       out


### PR DESCRIPTION
## Summary
- clamp categorical bar plot grid inputs to the rendered layout so the controls always match the plot
- apply the same layout clamping to the numeric box plot controls to remove the transient grid resizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69009f5b8e68832b91e34bdd30781c9a