### PR TITLE
Add safeguard for high-cardinality stratification

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -104,18 +104,10 @@ prepare_stratified_anova <- function(
   }
   
   if (!is.null(stratify_var) && stratify_var %in% names(df)) {
-    n_levels <- length(unique(na.omit(df[[stratify_var]])))
-    
-    validate(
-      need(
-        n_levels <= 10,
-        paste0(
-          "❌ Stratification variable '", stratify_var,
-          "' has ", n_levels, " levels — please select a variable with at most 10."
-        )
-      )
-    )
-    
+    if (!guard_stratification_levels(df, stratify_var)) {
+      return(NULL)
+    }
+
     if (!is.null(strata_order) && length(strata_order) > 0) {
       df[[stratify_var]] <- factor(as.character(df[[stratify_var]]), levels = strata_order)
     } else {

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -180,17 +180,8 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       
       # ---- Validate stratification complexity ----
       strat_var <- input$stratify_var
-      if (!is.null(strat_var) && strat_var != "None" && strat_var %in% names(df)) {
-        n_levels <- length(unique(na.omit(df[[strat_var]])))
-        validate(
-          need(
-            n_levels <= 10,
-            paste0(
-              "❌ Stratification variable '", strat_var,
-              "' has ", n_levels, " levels — please select a variable with at most 10."
-            )
-          )
-        )
+      if (!guard_stratification_levels(df, strat_var)) {
+        return(NULL)
       }
 
       rhs <- reg_compose_rhs(

--- a/R/ui_stratification.R
+++ b/R/ui_stratification.R
@@ -7,6 +7,42 @@
   if (is.function(data)) data() else data
 }
 
+MAX_STRATIFICATION_LEVELS <- 10
+
+guard_stratification_levels <- function(data, stratify_var,
+                                        max_levels = MAX_STRATIFICATION_LEVELS,
+                                        session = shiny::getDefaultReactiveDomain(),
+                                        notify = TRUE) {
+  if (is.null(stratify_var) || identical(stratify_var, "None") || identical(stratify_var, "")) {
+    return(TRUE)
+  }
+
+  df <- .resolve_data(data)
+  if (is.null(df) || !is.data.frame(df) || !(stratify_var %in% names(df))) {
+    return(TRUE)
+  }
+
+  values <- df[[stratify_var]]
+  values <- values[!is.na(values)]
+  n_levels <- length(unique(as.character(values)))
+
+  if (n_levels <= max_levels) {
+    return(TRUE)
+  }
+
+  message <- paste0(
+    "❌ Stratification variable '", stratify_var,
+    "' has ", n_levels,
+    " levels — please select a variable with at most ", max_levels, "."
+  )
+
+  if (isTRUE(notify) && !is.null(session)) {
+    shiny::showNotification(message, type = "error", duration = 8)
+  }
+
+  FALSE
+}
+
 # ---------------------------------------------------------------
 # Stratification options panel (select strat variable + placeholder for order)
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a shared guard to stop computations and raise a notification when a stratification exceeds the 10-level limit
- apply the guard across ANOVA, regression, and descriptive modules while hardening downstream reactives for NULL results

## Testing
- Not run (Rscript not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6900a57482b8832b82cf0c78127c5e2b