### PR TITLE
Fix descriptive stratification handling and boxplot data source

### DIFF
--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -70,13 +70,9 @@ descriptive_server <- function(id, filtered_data) {
         return(NULL)
       }
 
+      data_columns <- selected_vars
+
       if (!is.null(group_var)) {
-        # make sure the group var is present
-        if (!(group_var %in% names(local_data))) {
-          selected_vars <- unique(c(selected_vars, group_var))
-          local_data <- local_data[, selected_vars, drop = FALSE]
-        }
-        
         # keep ONLY selected levels, in the exact order; drop NA and unused levels
         sel <- input$strata_order
         if (!is.null(sel) && length(sel) > 0) {
@@ -86,9 +82,13 @@ descriptive_server <- function(id, filtered_data) {
           local_data[[group_var]] <- factor(as.character(local_data[[group_var]]))
         }
         local_data <- droplevels(local_data)
+
+        data_columns <- unique(c(data_columns, group_var))
       }
 
-      local_data <- local_data[, selected_vars, drop = FALSE]
+      data_columns <- data_columns[!is.na(data_columns) & nzchar(data_columns)]
+      data_columns <- intersect(data_columns, names(local_data))
+      local_data <- local_data[, data_columns, drop = FALSE]
 
       if (!is.null(group_var) && !is.null(input$strata_order)) {
         if (group_var %in% names(local_data)) {

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -40,12 +40,15 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
     })
     
     plot_info <- reactive({
-      dat <- filtered_data()
       info <- summary_info()
-      
-      validate(need(!is.null(dat) && is.data.frame(dat) && nrow(dat) > 0, "No data available."))
+
       validate(need(!is.null(info), "Summary not available."))
-      
+
+      processed <- resolve_input_value(info$processed_data)
+      dat <- if (!is.null(processed)) processed else filtered_data()
+
+      validate(need(!is.null(dat) && is.data.frame(dat) && nrow(dat) > 0, "No data available."))
+
       selected_vars <- resolve_input_value(info$selected_vars)
       group_var     <- resolve_input_value(info$group_var)
       


### PR DESCRIPTION
## Summary
- ensure the descriptive summary retains the stratification column when subsetting to selected variables
- reuse the processed descriptive data when building numeric boxplots so stratification filters and levels are respected

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900a7e53298832ba9cd6731371847f4