### PR TITLE
Add numeric histogram visualization module

### DIFF
--- a/R/descriptive_visualize.R
+++ b/R/descriptive_visualize.R
@@ -49,7 +49,7 @@ visualize_descriptive_server <- function(id, filtered_data, descriptive_summary)
       switch(input$plot_type,
              "categorical" = visualize_categorical_barplots_ui(ns("categorical")),
              "boxplots"    = visualize_numeric_boxplots_ui(ns("boxplots")),
-             "histograms"  = h5("Histogram controls not yet implemented."),
+             "histograms"  = visualize_numeric_histograms_ui(ns("histograms")),
              "cv"          = h5("CV controls not yet implemented."),
              "outliers"    = h5("Outlier controls not yet implemented."),
              "missing"     = h5("Missingness controls not yet implemented."),
@@ -67,6 +67,7 @@ visualize_descriptive_server <- function(id, filtered_data, descriptive_summary)
       handle <- switch(type[[1]],
                        "categorical" = visualize_categorical_barplots_server("categorical", filtered_data, descriptive_summary),
                        "boxplots"    = visualize_numeric_boxplots_server("boxplots", filtered_data, descriptive_summary),
+                       "histograms"  = visualize_numeric_histograms_server("histograms", filtered_data, descriptive_summary),
                        NULL
       )
       active(handle)

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -1,0 +1,149 @@
+# ===============================================================
+# 🟦 Descriptive Visualization — Numeric Histograms
+# ===============================================================
+
+visualize_numeric_histograms_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    checkboxInput(ns("use_density"), "Show density instead of count", FALSE),
+    fluidRow(
+      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  400, 200, 2000, 50)),
+      column(6, numericInput(ns("plot_height"), "Subplot height (px)", 300, 200, 2000, 50))
+    ),
+    hr(),
+    fluidRow(
+      column(6, numericInput(ns("n_rows"), "Grid rows",    value = 2, min = 1, max = 10, step = 1)),
+      column(6, numericInput(ns("n_cols"), "Grid columns", value = 3, min = 1, max = 10, step = 1))
+    ),
+    hr(),
+    downloadButton(ns("download_plot"), "Download Plot")
+  )
+}
+
+
+visualize_numeric_histograms_server <- function(id, filtered_data, summary_info) {
+  moduleServer(id, function(input, output, session) {
+
+    resolve_input_value <- function(x) {
+      if (is.null(x)) return(NULL)
+      if (is.reactive(x)) x() else x
+    }
+
+    plot_width <- reactive({
+      w <- input$plot_width
+      if (is.null(w) || !is.numeric(w) || is.na(w)) 400 else w
+    })
+
+    plot_height <- reactive({
+      h <- input$plot_height
+      if (is.null(h) || !is.numeric(h) || is.na(h)) 300 else h
+    })
+
+    plot_info <- reactive({
+      info <- summary_info()
+
+      validate(need(!is.null(info), "Summary not available."))
+
+      processed <- resolve_input_value(info$processed_data)
+      dat <- if (!is.null(processed)) processed else filtered_data()
+
+      validate(need(!is.null(dat) && is.data.frame(dat) && nrow(dat) > 0, "No data available."))
+
+      selected_vars <- resolve_input_value(info$selected_vars)
+      group_var     <- resolve_input_value(info$group_var)
+      strata_levels <- resolve_input_value(info$strata_levels)
+
+      out <- build_descriptive_numeric_histogram(
+        df = dat,
+        selected_vars = selected_vars,
+        group_var = group_var,
+        strata_levels = strata_levels,
+        use_density = isTRUE(input$use_density),
+        nrow_input = input$n_rows,
+        ncol_input = input$n_cols
+      )
+
+      validate(need(!is.null(out), "No numeric variables available for plotting."))
+
+      n_panels <- out$panels
+      max_val  <- 10L
+
+      layout_info <- out$layout
+      if (is.null(layout_info) || !is.list(layout_info)) {
+        layout_info <- list()
+      }
+
+      safe_rows <- layout_info$nrow
+      safe_cols <- layout_info$ncol
+
+      if (is.null(safe_rows) || !is.finite(safe_rows)) {
+        safe_rows <- min(10L, max(1L, as.integer(n_panels)))
+      }
+      if (is.null(safe_cols) || !is.finite(safe_cols)) {
+        safe_cols <- min(10L, max(1L, ceiling(as.integer(n_panels) / max(1L, safe_rows))))
+      }
+
+      safe_rows <- min(max(1L, as.integer(safe_rows)), max_val)
+      safe_cols <- min(max(1L, as.integer(safe_cols)), max_val)
+
+      current_rows <- suppressWarnings(as.integer(input$n_rows))
+      current_cols <- suppressWarnings(as.integer(input$n_cols))
+
+      if (length(current_rows) == 0 || is.na(current_rows)) current_rows <- NULL
+      if (length(current_cols) == 0 || is.na(current_cols)) current_cols <- NULL
+
+      isolate({
+        if (!identical(current_rows, safe_rows)) {
+          updateNumericInput(session, "n_rows", value = safe_rows, min = 1, max = max_val)
+        } else {
+          updateNumericInput(session, "n_rows", min = 1, max = max_val)
+        }
+
+        if (!identical(current_cols, safe_cols)) {
+          updateNumericInput(session, "n_cols", value = safe_cols, min = 1, max = max_val)
+        } else {
+          updateNumericInput(session, "n_cols", min = 1, max = max_val)
+        }
+      })
+
+      out
+    })
+
+    plot_size <- reactive({
+      info <- plot_info()
+      if (is.null(info$layout)) {
+        list(w = plot_width(), h = plot_height())
+      } else {
+        list(
+          w = plot_width()  * info$layout$ncol,
+          h = plot_height() * info$layout$nrow
+        )
+      }
+    })
+
+    output$download_plot <- downloadHandler(
+      filename = function() paste0("numeric_histograms_", Sys.Date(), ".png"),
+      content  = function(file) {
+        info <- plot_info()
+        req(info$plot)
+        s <- plot_size()
+        ggplot2::ggsave(
+          filename = file,
+          plot = info$plot,
+          device = "png",
+          dpi = 300,
+          width  = s$w / 96,
+          height = s$h / 96,
+          units = "in",
+          limitsize = FALSE
+        )
+      }
+    )
+
+    return(list(
+      plot   = reactive({ plot_info()$plot }),
+      width  = reactive(plot_size()$w),
+      height = reactive(plot_size()$h)
+    ))
+  })
+}

--- a/R/module_visualize_plot_builders.R
+++ b/R/module_visualize_plot_builders.R
@@ -305,6 +305,114 @@ build_descriptive_numeric_boxplot <- function(df,
 }
 
 
+build_descriptive_numeric_histogram <- function(df,
+                                                selected_vars = NULL,
+                                                group_var = NULL,
+                                                strata_levels = NULL,
+                                                use_density = FALSE,
+                                                nrow_input = NULL,
+                                                ncol_input = NULL) {
+  if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) return(NULL)
+
+  num_vars <- names(df)[vapply(df, is.numeric, logical(1))]
+  if (!is.null(selected_vars) && length(selected_vars) > 0) {
+    num_vars <- intersect(num_vars, selected_vars)
+  }
+  if (length(num_vars) == 0) return(NULL)
+
+  if (!is.null(group_var) && group_var %in% names(df)) {
+    df[[group_var]] <- as.character(df[[group_var]])
+    df[[group_var]][is.na(df[[group_var]]) | trimws(df[[group_var]]) == ""] <- "Missing"
+
+    if (!is.null(strata_levels) && length(strata_levels) > 0) {
+      keep_levels <- unique(strata_levels)
+      df <- df[df[[group_var]] %in% keep_levels, , drop = FALSE]
+      if (nrow(df) == 0) return(NULL)
+      df[[group_var]] <- factor(df[[group_var]], levels = keep_levels)
+    } else {
+      df[[group_var]] <- factor(df[[group_var]], levels = unique(df[[group_var]]))
+    }
+  } else {
+    group_var <- NULL
+  }
+
+  plots <- lapply(num_vars, function(var) {
+    cols <- c(var, group_var)
+    cols <- cols[cols %in% names(df)]
+    plot_data <- df[, cols, drop = FALSE]
+
+    keep <- is.finite(plot_data[[var]])
+    keep[is.na(keep)] <- FALSE
+    plot_data <- plot_data[keep, , drop = FALSE]
+    if (nrow(plot_data) == 0) return(NULL)
+
+    if (!is.null(group_var)) {
+      plot_data[[group_var]] <- droplevels(plot_data[[group_var]])
+    }
+
+    density_mode <- isTRUE(use_density) && length(unique(plot_data[[var]])) > 1
+
+    base <- ggplot(plot_data, aes(x = .data[[var]]))
+    y_label <- if (density_mode) "Density" else "Count"
+
+    if (!is.null(group_var)) {
+      if (density_mode) {
+        p <- base +
+          geom_density(aes(color = .data[[group_var]], fill = .data[[group_var]]), alpha = 0.3) +
+          labs(color = group_var, fill = group_var)
+      } else {
+        p <- base +
+          geom_histogram(
+            aes(fill = .data[[group_var]]),
+            position = "identity",
+            alpha = 0.5,
+            bins = 30,
+            color = "white"
+          ) +
+          labs(fill = group_var)
+      }
+    } else {
+      if (density_mode) {
+        p <- base + geom_density(fill = "#2C7FB8", color = "#2C7FB8", alpha = 0.35)
+      } else {
+        p <- base + geom_histogram(fill = "#FDBF6F", color = "white", bins = 30)
+      }
+    }
+
+    p +
+      theme_minimal(base_size = 13) +
+      labs(title = var, x = var, y = y_label)
+  })
+
+  plots <- Filter(Negate(is.null), plots)
+  if (length(plots) == 0) return(NULL)
+
+  layout <- resolve_grid_layout(
+    n_items = length(plots),
+    rows_input = suppressWarnings(as.numeric(nrow_input)),
+    cols_input = suppressWarnings(as.numeric(ncol_input))
+  )
+
+  title_text <- if (isTRUE(use_density)) {
+    "Numeric Distributions (Density)"
+  } else {
+    "Numeric Distributions (Histograms)"
+  }
+
+  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
+    patchwork::plot_annotation(
+      title = title_text,
+      theme = theme(plot.title = element_text(size = 16, face = "bold"))
+    )
+
+  list(
+    plot = combined,
+    layout = list(nrow = layout$nrow, ncol = layout$ncol),
+    panels = length(plots)
+  )
+}
+
+
 build_descriptive_histogram <- function(df) {
   num_vars <- names(df)[sapply(df, is.numeric)]
   if (length(num_vars) == 0) return(NULL)


### PR DESCRIPTION
## Summary
- add UI and server modules for numeric histograms with density toggle and layout controls
- support grouped histograms/densities via a dedicated plot builder
- wire the histogram module into the descriptive visualization dispatcher

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900ac9b5778832bbd35c93ca2441d02