### PR TITLE
Remove global plot titles across visualization modules

### DIFF
--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -137,7 +137,7 @@ prepare_metric_data <- function(data, numeric_vars, group_var, strata_levels, me
 }
 
 
-build_metric_plot <- function(metric_info, y_label, title, n_rows, n_cols) {
+build_metric_plot <- function(metric_info, y_label, n_rows, n_cols) {
   df <- metric_info$data
   has_group <- isTRUE(metric_info$has_group)
 
@@ -158,13 +158,13 @@ build_metric_plot <- function(metric_info, y_label, title, n_rows, n_cols) {
   p +
     facet_wrap(~ variable, nrow = n_rows, ncol = n_cols, scales = "free_y") +
     theme_minimal(base_size = 13) +
-    labs(x = NULL, y = y_label, title = title) +
+    labs(x = NULL, y = y_label) +
     theme(axis.text.x = element_text(angle = 45, hjust = 1))
 }
 
 
 metric_module_server <- function(id, filtered_data, summary_info, metric_key,
-                                 y_label, title, filename_prefix) {
+                                 y_label, filename_prefix) {
   moduleServer(id, function(input, output, session) {
 
     plot_width <- reactive({
@@ -214,7 +214,7 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       n_rows <- safe_numeric_input(input$n_rows, default = 1L)
       n_cols <- safe_numeric_input(input$n_cols, default = 1L)
 
-      plot <- build_metric_plot(metric_info, y_label, title, n_rows, n_cols)
+      plot <- build_metric_plot(metric_info, y_label, n_rows, n_cols)
 
       list(
         plot = plot,
@@ -269,7 +269,6 @@ visualize_cv_server <- function(id, filtered_data, summary_info) {
     summary_info = summary_info,
     metric_key = "cv",
     y_label = "CV (%)",
-    title = "Coefficient of Variation (CV%)",
     filename_prefix = "cv_summary"
   )
 }
@@ -281,7 +280,6 @@ visualize_outliers_server <- function(id, filtered_data, summary_info) {
     summary_info = summary_info,
     metric_key = "outliers",
     y_label = "Outlier Count",
-    title = "Outlier Counts (1.5×IQR Rule)",
     filename_prefix = "outlier_summary"
   )
 }
@@ -293,7 +291,6 @@ visualize_missing_server <- function(id, filtered_data, summary_info) {
     summary_info = summary_info,
     metric_key = "missing",
     y_label = "Missing (%)",
-    title = "Missingness (%)",
     filename_prefix = "missing_summary"
   )
 }

--- a/R/module_visualize_plot_builders.R
+++ b/R/module_visualize_plot_builders.R
@@ -62,8 +62,7 @@ build_descriptive_metric_panel <- function(df, prefix, y_label) {
   tidy <- tidy_descriptive_metric(df, prefix)
   if (is.null(tidy)) return(NULL)
 
-  plot <- build_descriptive_metric_bar_plot(tidy, y_label)
-  plot + ggtitle(paste("Summary Metric:", y_label))
+  build_descriptive_metric_bar_plot(tidy, y_label)
 }
 
 
@@ -236,11 +235,7 @@ build_descriptive_categorical_plot <- function(df,
     cols_input = suppressWarnings(as.numeric(ncol_input))
   )
   
-  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
-    patchwork::plot_annotation(
-      title = "Categorical Distributions",
-      theme = theme(plot.title = element_text(size = 16, face = "bold"))
-    )
+  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol)
   
   list(
     plot = combined,
@@ -306,11 +301,7 @@ build_descriptive_numeric_boxplot <- function(df,
     cols_input = suppressWarnings(as.numeric(ncol_input))
   )
   
-  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
-    patchwork::plot_annotation(
-      title = "Numeric Distributions (Boxplots)",
-      theme = theme(plot.title = element_text(size = 16, face = "bold"))
-    )
+  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol)
   
   list(
     plot = combined,
@@ -408,17 +399,7 @@ build_descriptive_numeric_histogram <- function(df,
     cols_input = suppressWarnings(as.numeric(ncol_input))
   )
 
-  title_text <- if (isTRUE(use_density)) {
-    "Numeric Distributions (Density)"
-  } else {
-    "Numeric Distributions (Histograms)"
-  }
-
-  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
-    patchwork::plot_annotation(
-      title = title_text,
-      theme = theme(plot.title = element_text(size = 16, face = "bold"))
-    )
+  combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol)
 
   list(
     plot = combined,
@@ -437,11 +418,7 @@ build_descriptive_histogram <- function(df) {
       theme_minimal(base_size = 13) +
       labs(title = paste(v, "Distribution"), x = NULL, y = "Frequency")
   })
-  patchwork::wrap_plots(plots, ncol = 2) +
-    patchwork::plot_annotation(
-      title = "Histograms",
-      theme = theme(plot.title = element_text(size = 16, face = "bold"))
-    )
+  patchwork::wrap_plots(plots, ncol = 2)
 }
 
 
@@ -490,7 +467,7 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
     }
   }
 
-  build_plot <- function(stats_df, title_text, y_limits) {
+  build_plot <- function(stats_df, y_limits) {
     single_col <- if (!is.null(line_colors) && length(line_colors) == 1) line_colors else "steelblue"
     
     if (is.null(factor2)) {
@@ -537,8 +514,7 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
       p <- p + scale_y_continuous(limits = y_limits)
     }
     
-    p + ggtitle(title_text) +
-      theme(plot.title = element_text(size = 12, face = "bold"))
+    p
   }
 
   for (resp in responses) {
@@ -563,7 +539,7 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
       if (!all(is.finite(y_limits))) y_limits <- NULL
 
       strata_plot_list <- lapply(names(stratum_plots), function(stratum_name) {
-        build_plot(stratum_plots[[stratum_name]], stratum_name, y_limits)
+        build_plot(stratum_plots[[stratum_name]], y_limits)
       })
 
       layout <- resolve_grid_layout(
@@ -581,15 +557,7 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
         ncol = layout$ncol
       )
 
-      title_plot <- ggplot() +
-        theme_void() +
-        ggtitle(resp) +
-        theme(
-          plot.title = element_text(size = 16, face = "bold", hjust = 0.5),
-          plot.margin = margin(t = 0, r = 0, b = 6, l = 0)
-        )
-
-      response_plots[[resp]] <- title_plot / combined + plot_layout(heights = c(0.08, 1))
+      response_plots[[resp]] <- combined
 
     } else {
       stats_df <- compute_stats(data, resp)
@@ -603,7 +571,7 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
         y_limits <- NULL
       }
 
-      response_plots[[resp]] <- build_plot(stats_df, resp, y_limits)
+      response_plots[[resp]] <- build_plot(stats_df, y_limits)
       max_strata_rows <- max(max_strata_rows, 1)
       max_strata_cols <- max(max_strata_cols, 1)
     }
@@ -662,7 +630,6 @@ build_ggpairs_plot <- function(data) {
       panel.grid.minor = element_blank(),
       panel.grid.major.x = element_blank(),
       panel.grid.major.y = element_blank(),
-      plot.title = element_text(size = 12, face = "bold"),
       axis.text = element_text(color = "black")
     )
 }
@@ -706,14 +673,12 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
     ) +
     theme_minimal(base_size = 14) +
     labs(
-      title = "PCA Biplot",
       x = "PC1",
       y = "PC2",
       color = if (!is.null(color_var)) color_var else NULL,
       shape = if (!is.null(shape_var)) shape_var else NULL
     ) +
     theme(
-      plot.title = element_text(size = 16, face = "bold"),
       legend.position = "right"
     )
   


### PR DESCRIPTION
## Summary
- remove global ggplot titles from shared visualization helpers so composite charts no longer render overarching headings
- update descriptive metric module to drop plot title usage while preserving facet and axis labeling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900bc0a647c832bab8cb26a3fe1451e