### PR TITLE
Normalize UI labels across modules

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -11,8 +11,8 @@ one_way_anova_ui <- function(id) {
       uiOutput(ns("advanced_options")),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Run", width = "100%")),
-        column(6, downloadButton(ns("download_all"), "Download All Results", width = "100%"))
+        column(6, actionButton(ns("run"), "Show results", width = "100%")),
+        column(6, downloadButton(ns("download_all"), "Download all results", width = "100%"))
       )
     ),
     results = tagList(

--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -7,7 +7,7 @@ visualize_oneway_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 4 — Visualize One-way ANOVA"),
+      h4("Step 4 — Visualize one-way ANOVA"),
       p("Select visualization type and adjust subplot layout, axis scaling, and figure size."),
       hr(),
       selectInput(
@@ -25,7 +25,7 @@ visualize_oneway_ui <- function(id) {
       hr(),
       add_color_customization_ui(ns, multi_group = FALSE),
       hr(),
-      downloadButton(ns("download_plot"), "Download Plot")
+      downloadButton(ns("download_plot"), "Download plot")
     ),
     mainPanel(
       width = 8,

--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -71,7 +71,7 @@ build_anova_layout_controls <- function(ns, input, info, default_ui_value) {
   }
   
   tagList(
-    h4("Layout Controls"),
+    h4("Layout controls"),
     strata_inputs,
     response_inputs
   )

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -12,8 +12,8 @@ two_way_anova_ui <- function(id) {
       uiOutput(ns("advanced_options")),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Run", width = "100%")),
-        column(6, downloadButton(ns("download_all"), "Download All Results"))
+        column(6, actionButton(ns("run"), "Show results", width = "100%")),
+        column(6, downloadButton(ns("download_all"), "Download all results"))
       )
     ),
     results = tagList(
@@ -40,7 +40,7 @@ two_way_anova_server <- function(id, filtered_data) {
       cat_cols <- names(data)[sapply(data, function(x) is.character(x) || is.factor(x))]
       
       tagList(
-        checkboxInput(ns("multi_resp"), "Enable multiple response variables", value = FALSE),
+        checkboxInput(ns("multi_resp"), "Show multiple response variables", value = FALSE),
         uiOutput(ns("response_selector")),
         selectInput(
           ns("factor1"),
@@ -77,7 +77,7 @@ two_way_anova_server <- function(id, filtered_data) {
       levels1 <- unique(as.character(df()[[input$factor1]]))
       selectInput(
         ns("order1"),
-        paste("Order of levels for", input$factor1, "(x-axis):"),
+        paste("Order of levels (first = reference):", input$factor1, "(x-axis)"),
         choices = levels1,
         selected = levels1,
         multiple = TRUE
@@ -89,7 +89,7 @@ two_way_anova_server <- function(id, filtered_data) {
       levels2 <- unique(as.character(df()[[input$factor2]]))
       selectInput(
         ns("order2"),
-        paste("Order of levels for", input$factor2, "(lines):"),
+        paste("Order of levels (first = reference):", input$factor2, "(lines)"),
         choices = levels2,
         selected = levels2,
         multiple = TRUE

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -7,7 +7,7 @@ visualize_twoway_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 4 — Visualize Two-way ANOVA"),
+      h4("Step 4 — Visualize two-way ANOVA"),
       p("Select visualization type and adjust subplot layout, axis scaling, and figure size."),
       hr(),
       selectInput(
@@ -25,7 +25,7 @@ visualize_twoway_ui <- function(id) {
       hr(),
       add_color_customization_ui(ns, multi_group = TRUE),
       hr(),
-      downloadButton(ns("download_plot"), "Download Plot")
+      downloadButton(ns("download_plot"), "Download plot")
     ),
     mainPanel(
       width = 8,

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -10,8 +10,8 @@ descriptive_ui <- function(id) {
       uiOutput(ns("advanced_options")),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Run", width = "100%")),
-        column(6, downloadButton(ns("download_summary"), "Download Summary", width = "100%"))
+        column(6, actionButton(ns("run"), "Show summary", width = "100%")),
+        column(6, downloadButton(ns("download_summary"), "Download summary", width = "100%"))
       ),
       hr()
     ),

--- a/R/descriptive_visualize.R
+++ b/R/descriptive_visualize.R
@@ -7,18 +7,18 @@ visualize_descriptive_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 5 — Visualize Descriptive Statistics"),
+      h4("Step 5 — Visualize descriptive statistics"),
       p("Explore distributions, variability, and normality across variables."),
       hr(),
       selectInput(
         ns("plot_type"),
         label = "Visualization type:",
         choices = c(
-          "Categorical Distributions" = "categorical",
-          "Numeric Boxplots"          = "boxplots",
-          "Numeric Histograms"        = "histograms",
+          "Categorical distributions" = "categorical",
+          "Numeric boxplots"          = "boxplots",
+          "Numeric histograms"        = "histograms",
           "CV (%)"                    = "cv",
-          "Outlier Counts"            = "outliers",
+          "Outlier counts"            = "outliers",
           "Missingness (%)"           = "missing"
         ),
         selected = "categorical"

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -36,7 +36,7 @@ visualize_categorical_barplots_ui <- function(id) {
       )
     ),
     hr(),
-    downloadButton(ns("download_plot"), "Download Plot")
+    downloadButton(ns("download_plot"), "Download plot")
   )
 }
 

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -17,7 +17,7 @@ metric_panel_ui <- function(id, default_width = 400, default_height = 300,
       column(6, numericInput(ns("n_cols"), "Grid columns", value = default_cols, min = 1, max = 10, step = 1))
     ),
     hr(),
-    downloadButton(ns("download_plot"), "Download Plot")
+    downloadButton(ns("download_plot"), "Download plot")
   )
 }
 

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -36,7 +36,7 @@ visualize_numeric_boxplots_ui <- function(id) {
       )
     ),
     hr(),
-    downloadButton(ns("download_plot"), "Download Plot")
+    downloadButton(ns("download_plot"), "Download plot")
   )
 }
 

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -16,7 +16,7 @@ visualize_numeric_histograms_ui <- function(id) {
       column(6, numericInput(ns("n_cols"), "Grid columns", value = 3, min = 1, max = 10, step = 1))
     ),
     hr(),
-    downloadButton(ns("download_plot"), "Download Plot")
+    downloadButton(ns("download_plot"), "Download plot")
   )
 }
 

--- a/R/module_analysis.R
+++ b/R/module_analysis.R
@@ -7,8 +7,8 @@ analysis_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 3 — Analyze Results"),
-      p("Choose the statistical approach that fits your trial design, then inspect the summaries on the right."),
+      h4("Step 3 — Analyze results"),
+      p("Select the statistical approach that fits your trial design, then inspect the summaries on the right."),
       hr(),
       tags$style(HTML(sprintf("
         /* Make only this input's dropdown tall enough to show all items */
@@ -41,7 +41,7 @@ analysis_ui <- function(id) {
     ),
     mainPanel(
       width = 8,
-      h4("Analysis Results"),
+      h4("Analysis results"),
       uiOutput(ns("results_panel"))
     )
   )

--- a/R/module_filter.R
+++ b/R/module_filter.R
@@ -7,8 +7,8 @@ filter_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 2 — Filter Records"),
-      p("Pick the columns to focus on and adjust the filters to refine the dataset for analysis."),
+      h4("Step 2 — Filter records"),
+      p("Select the columns to focus on and adjust the filters to refine the dataset for analysis."),
       hr(),
       uiOutput(ns("column_selector")),
       hr(),
@@ -16,7 +16,7 @@ filter_ui <- function(id) {
     ),
     mainPanel(
       width = 8,
-      h4("Filtered Data Preview"),
+      h4("Filtered data preview"),
       DTOutput(ns("filtered_preview"))
     )
   )

--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -7,7 +7,7 @@ upload_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 1 — Upload Data"),
+      h4("Step 1 — Upload data"),
       p("Upload your Excel file, choose the worksheet to analyze, and ensure the data follow either the long or wide format shown below."),
       hr(),
       radioButtons(
@@ -30,7 +30,7 @@ upload_ui <- function(id) {
     ),
     mainPanel(
       width = 8,
-      h4("Data Preview"),
+      h4("Data preview"),
       verbatimTextOutput(ns("validation_msg")),
       DTOutput(ns("preview"))
     )

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -10,12 +10,12 @@ ggpairs_ui <- function(id) {
       selectInput(ns("vars"), "Variables:", choices = NULL, multiple = TRUE),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Run", width = "100%")),
-        column(6, downloadButton(ns("download_model"), "Download All Results", width = "100%"))
+        column(6, actionButton(ns("run"), "Show correlation matrix", width = "100%")),
+        column(6, downloadButton(ns("download_model"), "Download all results", width = "100%"))
       )
     ),
     results = tagList(
-      h5("Correlation Matrix"),
+      h5("Correlation matrix"),
       verbatimTextOutput(ns("summary"))
     )
   )

--- a/R/pairwise_correlation_visualize.R
+++ b/R/pairwise_correlation_visualize.R
@@ -7,7 +7,7 @@ visualize_ggpairs_ui <- function(id) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 4 — Visualize Pairwise Correlation"),
+      h4("Step 4 — Visualize pairwise correlation"),
       p("Visualize pairwise relationships and correlation coefficients among numeric variables."),
       hr(),
       selectInput(
@@ -42,7 +42,7 @@ visualize_ggpairs_ui <- function(id) {
         )
       ),
       hr(),
-      downloadButton(ns("download_plot"), "Download Plot")
+      downloadButton(ns("download_plot"), "Download plot")
     ),
     mainPanel(
       width = 8,

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -9,12 +9,12 @@ pca_ui <- function(id) {
       p("Select numeric variables to include in the PCA. The data will be centered and scaled automatically."),
       selectInput(ns("vars"), "Variables:", choices = NULL, multiple = TRUE),
       fluidRow(
-        column(6, actionButton(ns("run_pca"), "Run", width = "100%")),
-        column(6, downloadButton(ns("download_all"), "Download All Results", width = "100%"))
+        column(6, actionButton(ns("run_pca"), "Show PCA summary", width = "100%")),
+        column(6, downloadButton(ns("download_all"), "Download all results", width = "100%"))
       )
     ),
     results = tagList(
-      h5("PCA Results Summary"),
+      h5("PCA results summary"),
       verbatimTextOutput(ns("summary")),
       DT::dataTableOutput(ns("loadings_table"))
     )

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -29,7 +29,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
   sidebarLayout(
     sidebarPanel(
       width = 4,
-      h4("Step 4 - Principal Component Analysis (PCA)"),
+      h4("Step 4 — Visualize principal component analysis (PCA)"),
       p("Visualize multivariate structure using a PCA biplot."),
       hr(),
       selectInput(
@@ -91,11 +91,11 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
         )
       ),
       hr(),
-      downloadButton(ns("download_plot"), "Download Plot")
+      downloadButton(ns("download_plot"), "Download plot")
     ),
     mainPanel(
       width = 8,
-      h4("PCA Biplot"),
+      h4("PCA biplot"),
       plotOutput(ns("plot"))
     )
   )

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -20,8 +20,8 @@ regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FA
       uiOutput(ns("formula_preview")),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Run", width = "100%")),
-        column(6, downloadButton(ns("download_model"), "Download All Results", width = "100%"))
+        column(6, actionButton(ns("run"), "Show results", width = "100%")),
+        column(6, downloadButton(ns("download_model"), "Download all results", width = "100%"))
       )
     ),
     results = tagList(
@@ -80,7 +80,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
           }
           selectInput(
             ns(paste0("order_", var)),
-            paste("Order of levels for", var, "(first = reference):"),
+            paste("Order of levels (first = reference):", var),
             choices = lvls,
             selected = lvls,
             multiple = TRUE
@@ -334,7 +334,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
             column(6, plotOutput(ns(paste0("qq_", idx))))
           ),
           br(),
-          downloadButton(ns(paste0("download_", idx)), "Download Results")
+          downloadButton(ns(paste0("download_", idx)), "Download results")
         )
       } else {
           stratum_tabs <- lapply(seq_along(strata), function(j) {
@@ -351,7 +351,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
                 column(6, plotOutput(ns(paste0("qq_", idx, "_", j))))
               ),
               br(),
-              downloadButton(ns(paste0("download_", idx, "_", j)), "Download Results")
+              downloadButton(ns(paste0("download_", idx, "_", j)), "Download results")
             )
           } else {
             div(

--- a/R/regression_analysis_shared.R
+++ b/R/regression_analysis_shared.R
@@ -35,7 +35,7 @@ reg_interactions_ui <- function(ns, fixed, fac_vars) {
   pair_values <- vapply(pairs, function(p) paste(p, collapse = ":"), character(1))
   checkboxGroupInput(
     ns("interactions"),
-    label = "Add 2-way interactions (optional):",
+    label = "Select 2-way interactions (optional):",
     choices = stats::setNames(pair_values, pair_labels)
   )
 }

--- a/R/ui_multiple_responses.R
+++ b/R/ui_multiple_responses.R
@@ -16,7 +16,7 @@ render_response_inputs <- function(ns, data, input) {
   tagList(
     checkboxInput(
       ns("multi_resp"),
-      "Enable multiple response variables",
+      "Show multiple response variables",
       value = isTRUE(input$multi_resp)
     ),
     selectInput(

--- a/R/ui_stratification.R
+++ b/R/ui_stratification.R
@@ -96,7 +96,7 @@ render_strata_order_input <- function(ns, data, strat_var,
   if (length(strata_levels) == 0) return(NULL)
   
   if (is.null(order_label)) {
-    order_label <- paste("Order of levels for", strat_var, "(strata):")
+    order_label <- "Order of levels (first = reference):"
   }
   
   selectInput(


### PR DESCRIPTION
## Summary
- align upload, filter, analysis, and visualization step headings with the sentence-case style guide
- standardize download buttons, action labels, and level ordering prompts across ANOVA, regression, descriptive, PCA, and correlation modules
- update shared helpers so multi-response and interaction controls use the mandated verb choices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900c3375510832bb788cde25f2d79be