### PR TITLE
Apply unified color palette across plots

### DIFF
--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -146,12 +146,14 @@ build_metric_plot <- function(metric_info, y_label, title, n_rows, n_cols) {
 
   if (has_group) {
     legend_title <- if (!is.null(metric_info$group_label)) metric_info$group_label else "Group"
+    palette <- resolve_palette_for_levels(levels(df$.group))
     p <- ggplot(df, aes(x = .group, y = value, fill = .group)) +
       geom_col(position = "dodge", width = 0.65) +
+      scale_fill_manual(values = palette) +
       labs(fill = legend_title)
   } else {
     p <- ggplot(df, aes(x = .group, y = value)) +
-      geom_col(width = 0.65, fill = "#2C7FB8") +
+      geom_col(width = 0.65, fill = resolve_single_color()) +
       guides(fill = "none")
   }
 

--- a/R/module_colors_helpers.R
+++ b/R/module_colors_helpers.R
@@ -5,7 +5,7 @@
 render_color_inputs <- function(ns, data, color_var) {
   if (is.null(color_var) || color_var == "None") return(NULL)
   if (!color_var %in% names(data())) return(NULL)
-  
+
   values <- data()[[color_var]]
   lvls <- if (is.factor(values)) levels(values) else unique(as.character(values))
   lvls <- lvls[!is.na(lvls)]
@@ -29,4 +29,42 @@ render_color_inputs <- function(ns, data, color_var) {
       )
     })
   )
+}
+
+resolve_single_color <- function() {
+  basic_color_palette[1]
+}
+
+resolve_palette_for_levels <- function(levels, custom = NULL) {
+  if (is.null(levels) || length(levels) == 0) {
+    return(resolve_single_color())
+  }
+
+  unique_levels <- unique(as.character(levels))
+  palette_size <- length(basic_color_palette)
+  n_levels <- length(unique_levels)
+
+  if (n_levels > palette_size) {
+    stop(
+      sprintf(
+        "Palette can assign at most %d groups but received %d levels.",
+        palette_size,
+        n_levels
+      ),
+      call. = FALSE
+    )
+  }
+
+  if (!is.null(custom) && length(custom) > 0) {
+    if (!is.null(names(custom))) {
+      ordered <- custom[unique_levels]
+      if (all(!is.na(ordered))) {
+        return(ordered)
+      }
+    } else if (length(custom) >= n_levels) {
+      return(stats::setNames(custom[seq_len(n_levels)], unique_levels))
+    }
+  }
+
+  stats::setNames(basic_color_palette[seq_len(n_levels)], unique_levels)
 }


### PR DESCRIPTION
## Summary
- add helpers to expose the fixed application palette and resolve colors for grouping levels
- refactor visualization builders to draw all geoms with the shared palette for grouped and ungrouped data
- align descriptive metric panels with the shared palette and remove hard-coded color constants

## Testing
- Not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6900c743a634832ba6887a2f4f7e39ab