### PR TITLE
Fix reactive handling in descriptive visualization modules

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -44,8 +44,26 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
   moduleServer(id, function(input, output, session) {
     
     resolve_input_value <- function(x) {
-      if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.null(x)) {
+        return(NULL)
+      }
+
+      if (shiny::is.reactive(x)) {
+        return(x())
+      }
+
+      if (is.function(x)) {
+        res <- tryCatch(
+          list(value = x(), ok = TRUE),
+          error = function(e) list(value = NULL, ok = FALSE)
+        )
+        if (isTRUE(res$ok)) {
+          return(res$value)
+        }
+        return(NULL)
+      }
+
+      x
     }
     
     plot_width <- reactive({

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -37,8 +37,26 @@ visualize_missing_ui <- function(id) {
 
 # ---- Shared computation helpers ----
 resolve_metric_input <- function(x) {
-  if (is.null(x)) return(NULL)
-  if (is.reactive(x)) x() else x
+  if (is.null(x)) {
+    return(NULL)
+  }
+
+  if (shiny::is.reactive(x)) {
+    return(x())
+  }
+
+  if (is.function(x)) {
+    res <- tryCatch(
+      list(value = x(), ok = TRUE),
+      error = function(e) list(value = NULL, ok = FALSE)
+    )
+    if (isTRUE(res$ok)) {
+      return(res$value)
+    }
+    return(NULL)
+  }
+
+  x
 }
 
 safe_numeric_input <- function(value, default = 1L) {

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -45,8 +45,26 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
   moduleServer(id, function(input, output, session) {
     
     resolve_input_value <- function(x) {
-      if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.null(x)) {
+        return(NULL)
+      }
+
+      if (shiny::is.reactive(x)) {
+        return(x())
+      }
+
+      if (is.function(x)) {
+        res <- tryCatch(
+          list(value = x(), ok = TRUE),
+          error = function(e) list(value = NULL, ok = FALSE)
+        )
+        if (isTRUE(res$ok)) {
+          return(res$value)
+        }
+        return(NULL)
+      }
+
+      x
     }
     
     plot_width <- reactive({

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -25,8 +25,26 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info)
   moduleServer(id, function(input, output, session) {
 
     resolve_input_value <- function(x) {
-      if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.null(x)) {
+        return(NULL)
+      }
+
+      if (shiny::is.reactive(x)) {
+        return(x())
+      }
+
+      if (is.function(x)) {
+        res <- tryCatch(
+          list(value = x(), ok = TRUE),
+          error = function(e) list(value = NULL, ok = FALSE)
+        )
+        if (isTRUE(res$ok)) {
+          return(res$value)
+        }
+        return(NULL)
+      }
+
+      x
     }
 
     plot_width <- reactive({


### PR DESCRIPTION
## Summary
- update descriptive visualization helpers to evaluate reactive and callable inputs before use to avoid closure subsetting errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900ca2a8640832b8feb3887e2944351