### PR TITLE
Modularize pairwise correlation GGPairs visualization

### DIFF
--- a/R/pairwise_correlation_visualize.R
+++ b/R/pairwise_correlation_visualize.R
@@ -1,5 +1,5 @@
 # ===============================================================
-# 🧪 Visualization Module — Pairwise Correlation (GGpairs)
+# 🧪 Visualization Module — Pairwise Correlation (Dispatcher)
 # ===============================================================
 
 visualize_ggpairs_ui <- function(id) {
@@ -13,43 +13,15 @@ visualize_ggpairs_ui <- function(id) {
       selectInput(
         ns("plot_type"),
         label = "Select visualization type:",
-        choices = c("Pairwise correlation matrix" = "ggpairs"),  # ✅ single option for now
-        selected = "ggpairs"
+        choices = c("GGPairs" = "GGPairs"),
+        selected = "GGPairs"
       ),
       hr(),
-      uiOutput(ns("strata_selector")),
-      hr(),
-      fluidRow(
-        column(
-          width = 6,
-          numericInput(
-            ns("plot_width"),
-            label = "Plot width (px)",
-            value = 800,
-            min = 400,
-            max = 2000,
-            step = 100
-          )
-        ),
-        column(
-          width = 6,
-          numericInput(
-            ns("plot_height"),
-            label = "Plot height (px)",
-            value = 600,
-            min = 400,
-            max = 2000,
-            step = 100
-          )
-        )
-      ),
-      hr(),
-      downloadButton(ns("download_plot"), "Download plot")
+      uiOutput(ns("sub_controls"))
     ),
     mainPanel(
       width = 8,
-      h4("Plots"),
-      plotOutput(ns("plots"))
+      plotOutput(ns("plot"), height = "auto")
     )
   )
 }
@@ -58,106 +30,58 @@ visualize_ggpairs_ui <- function(id) {
 visualize_ggpairs_server <- function(id, filtered_data, model_fit) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    
-    # Reactive data and model
-    model_info <- reactive(model_fit())
 
-    stratified_results <- reactive({
-      info <- model_info()
-      if (is.null(info) || info$type != "pairwise_correlation") return(NULL)
-      res_accessor <- info$results
-      if (is.null(res_accessor) || !is.function(res_accessor)) return(NULL)
-      res_accessor()
-    })
-
-    available_strata <- reactive({
-      results <- stratified_results()
-      if (is.null(results) || is.null(results$plots)) return(NULL)
-      plots <- results$plots
-      if (is.null(plots) || length(plots) == 0) return(NULL)
-      nm <- names(plots)
-      if (is.null(nm) || length(nm) == 0) {
-        nm <- rep("Overall", length(plots))
-        names(plots) <- nm
+    correlation_info <- reactive({
+      info <- model_fit()
+      if (is.null(info) || is.null(info$type) || info$type != "pairwise_correlation") {
+        return(NULL)
       }
-      nm <- nm[nzchar(nm)]
-      if (length(nm) == 0) return(NULL)
-      nm
+      info
     })
 
-    output$strata_selector <- renderUI({
-      choices <- available_strata()
-      if (is.null(choices)) return(NULL)
-      selectInput(
-        ns("selected_stratum"),
-        label = "Select stratum:",
-        choices = choices,
-        selected = choices[[1]]
-      )
+    active <- reactiveVal(NULL)
+
+    output$sub_controls <- renderUI({
+      info <- correlation_info()
+      if (is.null(info)) {
+        helpText("Run the pairwise correlation analysis to configure plots.")
+      } else if (identical(input$plot_type, "GGPairs")) {
+        pairwise_correlation_visualize_ggpairs_ui(ns("ggpairs"))
+      } else {
+        NULL
+      }
     })
 
-    # Determine plot size dynamically
-    plot_size <- reactive({
-      list(w = input$plot_width, h = input$plot_height)
-    })
+    observeEvent(list(input$plot_type, correlation_info()), {
+      info <- correlation_info()
+      type <- input$plot_type
 
-    # --- Main Plot Rendering ---
-    output$plots <- renderPlot({
-      info <- model_info()
-      if (is.null(info) || info$type != "pairwise_correlation") return(NULL)
-      results <- stratified_results()
-      if (is.null(results) || is.null(results$plots) || length(results$plots) == 0) {
-        validate(need(FALSE, "No correlation results available."))
+      if (is.null(info) || is.null(type)) {
+        active(NULL)
+        return()
       }
 
-      # use visualization type (only one for now)
-      if (input$plot_type == "ggpairs") {
-        stratum <- input$selected_stratum
-        plots <- results$plots
-        if (is.null(stratum) || !stratum %in% names(plots)) {
-          stratum <- names(plots)[[1]]
-        }
-        plot_obj <- plots[[stratum]]
-        validate(need(!is.null(plot_obj), "Selected stratum has no data to plot."))
-        print(plot_obj)
-      }
+      handle <- switch(type,
+                       "GGPairs" = pairwise_correlation_visualize_ggpairs_server("ggpairs", filtered_data, correlation_info),
+                       NULL)
+      active(handle)
+    }, ignoreNULL = FALSE)
+
+    output$plot <- renderPlot({
+      h <- active()
+      req(h)
+      plot_obj <- h$plot()
+      validate(need(!is.null(plot_obj), "No plot available."))
+      print(plot_obj)
     },
-    width  = function() plot_size()$w,
-    height = function() plot_size()$h,
-    res    = 96)
-
-    # --- Download handler ---
-    output$download_plot <- downloadHandler(
-      filename = function() paste0("ggpairs_plot_", Sys.Date(), ".png"),
-      content = function(file) {
-        info <- model_info()
-        req(info)
-        validate(need(info$type == "pairwise_correlation", "Pairwise correlation results are not available."))
-        results <- stratified_results()
-        req(results)
-        plots <- results$plots
-        req(plots)
-        stratum <- input$selected_stratum
-        if (is.null(stratum) || !stratum %in% names(plots)) {
-          stratum <- names(plots)[[1]]
-        }
-        g <- plots[[stratum]]
-        validate(need(!is.null(g), "Selected stratum has no data to plot."))
-
-        width_in  <- input$plot_width / 96
-        height_in <- input$plot_height / 96
-
-        ggsave(
-          filename = file,
-          plot = g,
-          device = "png",
-          dpi = 300,
-          width = width_in,
-          height = height_in,
-          units = "in",
-          limitsize = FALSE
-        )
-      }
-    )
+    width = function() {
+      h <- active()
+      if (is.null(h)) 800 else h$width()
+    },
+    height = function() {
+      h <- active()
+      if (is.null(h)) 600 else h$height()
+    },
+    res = 96)
   })
 }

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -1,0 +1,208 @@
+# ===============================================================
+# 🧪 Pairwise Correlation — GGPairs Visualization Module
+# ===============================================================
+
+pairwise_correlation_visualize_ggpairs_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    fluidRow(
+      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  800, 200, 2000, 50)),
+      column(6, numericInput(ns("plot_height"), "Subplot height (px)", 600, 200, 2000, 50))
+    ),
+    fluidRow(
+      column(6, numericInput(ns("grid_rows"),    "Grid rows",    1, 1, 10, 1)),
+      column(6, numericInput(ns("grid_cols"),    "Grid columns", 1, 1, 10, 1))
+    ),
+    hr(),
+    downloadButton(ns("download_plot"), "Download Plot")
+  )
+}
+
+
+pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, correlation_info) {
+  moduleServer(id, function(input, output, session) {
+
+    resolve_input_value <- function(x) {
+      if (is.null(x)) return(NULL)
+      if (is.reactive(x)) x() else x
+    }
+
+    sanitize_numeric <- function(value, default, min_val, max_val) {
+      v <- suppressWarnings(as.numeric(value))
+      if (length(v) == 0 || is.na(v)) return(default)
+      v <- max(min_val, min(max_val, v))
+      v
+    }
+
+    plot_width <- reactive({
+      sanitize_numeric(input$plot_width, 800, 200, 2000)
+    })
+
+    plot_height <- reactive({
+      sanitize_numeric(input$plot_height, 600, 200, 2000)
+    })
+
+    grid_rows <- reactive({
+      as.integer(sanitize_numeric(input$grid_rows, 1, 1, 10))
+    })
+
+    grid_cols <- reactive({
+      as.integer(sanitize_numeric(input$grid_cols, 1, 1, 10))
+    })
+
+    build_ggpairs_plot <- function(data, color_value, title = NULL) {
+      validate(need(is.data.frame(data) && nrow(data) > 0, "No data available for plotting."))
+
+      numeric_cols <- data[, vapply(data, is.numeric, logical(1)), drop = FALSE]
+      numeric_cols <- numeric_cols[, colSums(!is.na(numeric_cols)) > 0, drop = FALSE]
+
+      validate(need(ncol(numeric_cols) >= 2, "Need at least two numeric columns for GGPairs plot."))
+
+      plot_obj <- GGally::ggpairs(
+        numeric_cols,
+        progress = FALSE,
+        upper = list(
+          continuous = GGally::wrap("cor", size = 4, colour = color_value)
+        ),
+        lower = list(
+          continuous = GGally::wrap("points", alpha = 0.6, colour = color_value, size = 1.5)
+        ),
+        diag = list(
+          continuous = GGally::wrap("densityDiag", fill = color_value, alpha = 0.4)
+        )
+      ) +
+        ggplot2::theme_minimal(base_size = 11) +
+        ggplot2::theme(
+          strip.text = ggplot2::element_text(face = "bold", size = 9),
+          panel.grid.minor = ggplot2::element_blank(),
+          panel.grid.major = ggplot2::element_blank()
+        )
+
+      if (!is.null(title)) {
+        plot_obj <- plot_obj + ggplot2::labs(title = title)
+      }
+
+      plot_obj
+    }
+
+    plot_info <- reactive({
+      info <- correlation_info()
+      validate(need(!is.null(info), "Correlation results are not available."))
+
+      results_accessor <- info$results
+      results <- resolve_input_value(results_accessor)
+
+      validate(need(!is.null(results), "Run the correlation analysis to generate plots."))
+
+      if (!is.null(results$message)) {
+        validate(need(FALSE, results$message))
+      }
+
+      data <- filtered_data()
+      validate(need(!is.null(data) && nrow(data) > 0, "No data available."))
+
+      selected_vars <- resolve_input_value(results$selected_vars)
+      if (is.null(selected_vars) || length(selected_vars) < 2) {
+        numeric_vars <- names(data)[vapply(data, is.numeric, logical(1))]
+        selected_vars <- numeric_vars
+      }
+
+      validate(need(length(selected_vars) >= 2, "Need at least two numeric columns for GGPairs plot."))
+
+      group_var <- resolve_input_value(info$group_var)
+      if (is.null(group_var) || identical(group_var, "None") || identical(group_var, "")) {
+        group_var <- NULL
+      }
+
+      strata_order <- resolve_input_value(info$strata_order)
+
+      if (is.null(group_var)) {
+        plot_data <- data[, selected_vars, drop = FALSE]
+        plot_obj <- build_ggpairs_plot(plot_data, basic_color_palette[1])
+        layout <- list(nrow = 1L, ncol = 1L)
+        list(plot = plot_obj, layout = layout)
+      } else {
+        available_levels <- NULL
+        if (!is.null(results$matrices)) {
+          available_levels <- names(results$matrices)
+        }
+        if (is.null(available_levels) || length(available_levels) == 0) {
+          available_levels <- unique(as.character(data[[group_var]]))
+        }
+        if (!is.null(strata_order) && length(strata_order) > 0) {
+          available_levels <- strata_order[strata_order %in% available_levels]
+        }
+        available_levels <- available_levels[nzchar(available_levels)]
+        validate(need(length(available_levels) > 0, "No strata available for plotting."))
+
+        colors <- basic_color_palette[seq_len(min(length(basic_color_palette), length(available_levels)))]
+        if (length(colors) < length(available_levels)) {
+          extra <- rep("#7F7F7F", length(available_levels) - length(colors))
+          colors <- c(colors, extra)
+        }
+        names(colors) <- available_levels
+
+        plots <- list()
+        for (level in available_levels) {
+          subset_rows <- !is.na(data[[group_var]]) & as.character(data[[group_var]]) == level
+          subset_data <- data[subset_rows, selected_vars, drop = FALSE]
+          if (nrow(subset_data) == 0) {
+            next
+          }
+          plots[[level]] <- build_ggpairs_plot(subset_data, colors[[level]], title = level)
+        }
+
+        validate(need(length(plots) > 0, "No data available for the selected strata."))
+
+        combined <- patchwork::wrap_plots(plotlist = plots, nrow = grid_rows(), ncol = grid_cols())
+        layout <- list(nrow = grid_rows(), ncol = grid_cols())
+        list(plot = combined, layout = layout)
+      }
+    })
+
+    plot_width_total <- reactive({
+      info <- plot_info()
+      layout <- info$layout
+      w <- plot_width()
+      if (!is.null(layout$ncol)) {
+        w <- w * max(1L, as.integer(layout$ncol))
+      }
+      w
+    })
+
+    plot_height_total <- reactive({
+      info <- plot_info()
+      layout <- info$layout
+      h <- plot_height()
+      if (!is.null(layout$nrow)) {
+        h <- h * max(1L, as.integer(layout$nrow))
+      }
+      h
+    })
+
+    output$download_plot <- downloadHandler(
+      filename = function() paste0("pairwise_correlation_ggpairs_", Sys.Date(), ".png"),
+      content = function(file) {
+        info <- plot_info()
+        plot_obj <- info$plot
+        req(plot_obj)
+        ggplot2::ggsave(
+          filename = file,
+          plot = plot_obj,
+          device = "png",
+          dpi = 300,
+          width = plot_width_total() / 96,
+          height = plot_height_total() / 96,
+          units = "in",
+          limitsize = FALSE
+        )
+      }
+    )
+
+    list(
+      plot = reactive({ plot_info()$plot }),
+      width = reactive(plot_width_total()),
+      height = reactive(plot_height_total())
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- add a dedicated pairwise correlation GGPairs visualization module with configurable sizing, layout, and downloads
- refactor the pairwise correlation visualization coordinator to dispatch to the new module and surface its plot reactives

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900db553590832baf81309c07506c55