### PR TITLE
Simplify descriptive visualization reactivity

### DIFF
--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -41,25 +41,44 @@ visualize_numeric_boxplots_ui <- function(id) {
 }
 
 
-visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
+visualize_numeric_boxplots_plot_ui <- function(id) {
+  ns <- NS(id)
+  div(
+    class = "ta-plot-container",
+    plotOutput(ns("plot"), width = "100%", height = "auto")
+  )
+}
+
+
+visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, is_active = NULL) {
   moduleServer(id, function(input, output, session) {
-    
+
     resolve_input_value <- function(x) {
       if (is.null(x)) return(NULL)
       if (is.reactive(x)) x() else x
     }
-    
+
+    module_active <- reactive({
+      if (is.null(is_active)) {
+        TRUE
+      } else {
+        isTRUE(is_active())
+      }
+    })
+
     plot_width <- reactive({
       w <- input$plot_width
       if (is.null(w) || !is.numeric(w) || is.na(w)) 400 else w
     })
-    
+
     plot_height <- reactive({
       h <- input$plot_height
       if (is.null(h) || !is.numeric(h) || is.na(h)) 300 else h
     })
-    
+
     plot_info <- reactive({
+      req(module_active())
+
       info <- summary_info()
 
       validate(need(!is.null(info), "Summary not available."))
@@ -84,8 +103,9 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
       validate(need(!is.null(out), "No numeric variables available for plotting."))
       out
     })
-    
+
     plot_size <- reactive({
+      req(module_active())
       info <- plot_info()
       if (is.null(info$layout)) {
         list(w = plot_width(), h = plot_height())
@@ -100,6 +120,7 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
     output$download_plot <- downloadHandler(
       filename = function() paste0("numeric_boxplots_", Sys.Date(), ".png"),
       content  = function(file) {
+        req(module_active())
         info <- plot_info()
         req(info$plot)
         s <- plot_size()
@@ -115,11 +136,21 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info) {
         )
       }
     )
-    
-    return(list(
-      plot   = reactive({ plot_info()$plot }),
-      width  = reactive(plot_size()$w),
-      height = reactive(plot_size()$h)
-    ))
+
+    output$plot <- renderPlot({
+      req(module_active())
+      info <- plot_info()
+      validate(need(!is.null(info$plot), "No plot available."))
+      print(info$plot)
+    },
+    width = function() {
+      req(module_active())
+      plot_size()$w
+    },
+    height = function() {
+      req(module_active())
+      plot_size()$h
+    },
+    res = 96)
   })
 }

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -21,13 +21,30 @@ visualize_numeric_histograms_ui <- function(id) {
 }
 
 
-visualize_numeric_histograms_server <- function(id, filtered_data, summary_info) {
+visualize_numeric_histograms_plot_ui <- function(id) {
+  ns <- NS(id)
+  div(
+    class = "ta-plot-container",
+    plotOutput(ns("plot"), width = "100%", height = "auto")
+  )
+}
+
+
+visualize_numeric_histograms_server <- function(id, filtered_data, summary_info, is_active = NULL) {
   moduleServer(id, function(input, output, session) {
 
     resolve_input_value <- function(x) {
       if (is.null(x)) return(NULL)
       if (is.reactive(x)) x() else x
     }
+
+    module_active <- reactive({
+      if (is.null(is_active)) {
+        TRUE
+      } else {
+        isTRUE(is_active())
+      }
+    })
 
     plot_width <- reactive({
       w <- input$plot_width
@@ -40,6 +57,8 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info)
     })
 
     plot_info <- reactive({
+      req(module_active())
+
       info <- summary_info()
 
       validate(need(!is.null(info), "Summary not available."))
@@ -110,6 +129,7 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info)
     })
 
     plot_size <- reactive({
+      req(module_active())
       info <- plot_info()
       if (is.null(info$layout)) {
         list(w = plot_width(), h = plot_height())
@@ -124,6 +144,7 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info)
     output$download_plot <- downloadHandler(
       filename = function() paste0("numeric_histograms_", Sys.Date(), ".png"),
       content  = function(file) {
+        req(module_active())
         info <- plot_info()
         req(info$plot)
         s <- plot_size()
@@ -140,10 +161,20 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info)
       }
     )
 
-    return(list(
-      plot   = reactive({ plot_info()$plot }),
-      width  = reactive(plot_size()$w),
-      height = reactive(plot_size()$h)
-    ))
+    output$plot <- renderPlot({
+      req(module_active())
+      info <- plot_info()
+      validate(need(!is.null(info$plot), "No plot available."))
+      print(info$plot)
+    },
+    width = function() {
+      req(module_active())
+      plot_size()$w
+    },
+    height = function() {
+      req(module_active())
+      plot_size()$h
+    },
+    res = 96)
   })
 }


### PR DESCRIPTION
## Summary
- rework the descriptive visualization dispatcher to mount submodule-specific plot outputs instead of proxying plot objects
- update each descriptive visualization submodule to manage its own plot rendering and download sizing while respecting module activity
- add shared plot containers for descriptive metric panels to keep layout stable when resizing grids

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901eed657a0832b99145c21df08dce1