### PR TITLE
Fix visualization helpers handling of closures

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -56,7 +56,7 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
 
     resolve_input_value <- function(x) {
       if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.reactive(x) || is.function(x)) x() else x
     }
 
     module_active <- reactive({
@@ -226,6 +226,10 @@ build_descriptive_categorical_plot <- function(df,
     cols_to_use <- c(var, group_col)
     cols_to_use <- cols_to_use[cols_to_use %in% names(df)]
     var_data <- df[, cols_to_use, drop = FALSE]
+
+    if (!is.null(group_col) && !group_col %in% names(var_data)) {
+      group_col <- NULL
+    }
     
     var_data[[var]] <- as.character(var_data[[var]])
     keep <- !is.na(var_data[[var]]) & trimws(var_data[[var]]) != ""

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -58,7 +58,7 @@ visualize_missing_plot_ui <- function(id) {
 # ---- Shared computation helpers ----
 resolve_metric_input <- function(x) {
   if (is.null(x)) return(NULL)
-  if (is.reactive(x)) x() else x
+  if (is.reactive(x) || is.function(x)) x() else x
 }
 
 safe_numeric_input <- function(value, default = 1L) {

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -55,7 +55,7 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
 
     resolve_input_value <- function(x) {
       if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.reactive(x) || is.function(x)) x() else x
     }
 
     module_active <- reactive({

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -35,7 +35,7 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
 
     resolve_input_value <- function(x) {
       if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.reactive(x) || is.function(x)) x() else x
     }
 
     module_active <- reactive({

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -24,7 +24,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
 
     resolve_input_value <- function(x) {
       if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
+      if (is.reactive(x) || is.function(x)) x() else x
     }
 
     sanitize_numeric <- function(value, default, min_val, max_val) {


### PR DESCRIPTION
## Summary
- treat reactive-like closures uniformly across visualization helpers to avoid passing functions downstream
- harden categorical barplot builder against missing grouping columns after data filtering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69034b196c58832b9ace900be022b5e1