### PR TITLE
Gracefully handle ANOVA and PCA model fitting errors

### DIFF
--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -59,20 +59,21 @@ pca_server <- function(id, filtered_data) {
         ))
       }
 
-      model <- tryCatch(
-        prcomp(numeric_subset, center = TRUE, scale. = TRUE),
-        error = function(e) e
-      )
+      safe_prcomp <- purrr::safely(function(mat) {
+        prcomp(mat, center = TRUE, scale. = TRUE)
+      })
 
-      if (inherits(model, "error")) {
+      model <- safe_prcomp(numeric_subset)
+
+      if (!is.null(model$error)) {
         return(list(
           model = NULL,
           data = plot_data,
-          message = conditionMessage(model)
+          message = conditionMessage(model$error)
         ))
       }
 
-      list(model = model, data = plot_data, message = NULL)
+      list(model = model$result, data = plot_data, message = NULL)
     }
 
     # Run PCA


### PR DESCRIPTION
## Summary
- wrap one-way and two-way ANOVA fits in `purrr::safely` and surface any fitting errors in the UI and downloads
- guard ANOVA exports against failed models so downloads only include successful fits
- run PCA fits through `purrr::safely` and report failures without breaking the analysis view

## Testing
- not run (Shiny app changes)


------
https://chatgpt.com/codex/tasks/task_e_690378b3bbe8832bbad44a91053ada0c