### PR TITLE
Normalize stratification selections before validation

### DIFF
--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -37,6 +37,11 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
+    random_effect <- reactive({
+      if (engine != "lmm") return(NULL)
+      reg_normalize_choice(input$random)
+    })
+
     output$response_ui <- renderUI({
       req(data())
       if (allow_multi_response) {
@@ -64,8 +69,9 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
 
       df <- data()
       fac_vars <- input$fixed
-      if (engine == "lmm" && !is.null(input$random) && nzchar(input$random)) {
-        fac_vars <- unique(c(fac_vars, input$random))
+      rand <- random_effect()
+      if (!is.null(rand)) {
+        fac_vars <- unique(c(fac_vars, rand))
       }
 
       if (length(fac_vars) == 0) return(NULL)
@@ -166,7 +172,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         input$fixed,
         input$covar,
         input$interactions,
-        if (engine == "lmm") input$random else NULL,
+        random_effect(),
         engine = engine
       )
       reg_formula_preview_ui(ns, responses[1], rhs)
@@ -188,7 +194,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         input$fixed,
         input$covar,
         input$interactions,
-        if (engine == "lmm") input$random else NULL,
+        random_effect(),
         engine = engine
       )
 

--- a/R/ui_stratification.R
+++ b/R/ui_stratification.R
@@ -9,11 +9,21 @@
 
 MAX_STRATIFICATION_LEVELS <- 10
 
+normalize_single_choice <- function(value) {
+  if (is.null(value)) return(NULL)
+  value <- value[!is.na(value)]
+  if (length(value) == 0) return(NULL)
+  value <- as.character(value[[1]])
+  if (!nzchar(value)) return(NULL)
+  value
+}
+
 guard_stratification_levels <- function(data, stratify_var,
                                         max_levels = MAX_STRATIFICATION_LEVELS,
                                         session = shiny::getDefaultReactiveDomain(),
                                         notify = TRUE) {
-  if (is.null(stratify_var) || identical(stratify_var, "None") || identical(stratify_var, "")) {
+  stratify_var <- normalize_single_choice(stratify_var)
+  if (is.null(stratify_var) || identical(stratify_var, "None")) {
     return(TRUE)
   }
 
@@ -77,6 +87,7 @@ render_advanced_options <- render_stratification_controls
 render_strata_order_input <- function(ns, data, strat_var,
                                       input_id = "strata_order",
                                       order_label = NULL) {
+  strat_var <- normalize_single_choice(strat_var)
   if (is.null(strat_var) || identical(strat_var, "None")) return(NULL)
   
   df <- .resolve_data(data)


### PR DESCRIPTION
## Summary
- add a helper that normalizes single-value stratification selections coming from Shiny inputs
- guard the stratification validator and order selector against empty values before reading data columns

## Testing
- not run (R executable is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_6908b0857c98832ba7be86ce8163cb82