### PR TITLE
Build stratification advanced options directly into module UIs

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -8,7 +8,10 @@ one_way_anova_ui <- function(id) {
     config = tagList(
       uiOutput(ns("inputs")),
       uiOutput(ns("level_order")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong(STRAT_SECTION_TITLE)),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show results", width = "100%")),
@@ -54,13 +57,7 @@ one_way_anova_server <- function(id, filtered_data) {
       render_response_inputs(ns, df(), input)
     })
     
-    output$advanced_options <- renderUI({
-      render_stratification_controls(ns, df, input)
-    })
-    
-    output$strata_order_ui <- renderUI({
-      render_strata_order_input(ns, df, input$stratify_var)
-    })
+    strat_info <- stratification_server("strat", df)
     
     # -----------------------------------------------------------
     # Level order selection
@@ -89,8 +86,7 @@ one_way_anova_server <- function(id, filtered_data) {
         model = "oneway_anova",
         factor1_var = input$group,
         factor1_order = input$order,
-        stratify_var = input$stratify_var,
-        strata_order = input$strata_order
+        stratification = strat_info()
       )
     })
     

--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -90,10 +90,20 @@ prepare_stratified_anova <- function(
     factor1_order = NULL,
     factor2_var = NULL,
     factor2_order = NULL,
+    stratification = NULL,
     stratify_var = NULL,
     strata_order = NULL
 ) {
   req(df, responses, model)
+
+  if (!is.null(stratification)) {
+    if (!is.null(stratification$var)) {
+      stratify_var <- stratification$var
+    }
+    if (!is.null(stratification$levels)) {
+      strata_order <- stratification$levels
+    }
+  }
   
   if (!is.null(factor1_var) && !is.null(factor1_order)) {
     df[[factor1_var]] <- factor(as.character(df[[factor1_var]]), levels = factor1_order)

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -9,7 +9,10 @@ two_way_anova_ui <- function(id) {
       uiOutput(ns("inputs")),
       uiOutput(ns("level_order_1")),
       uiOutput(ns("level_order_2")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong(STRAT_SECTION_TITLE)),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show results", width = "100%")),
@@ -61,13 +64,7 @@ two_way_anova_server <- function(id, filtered_data) {
       render_response_selector(ns, df, input)
     })
     
-    output$advanced_options <- renderUI({
-      render_stratification_controls(ns, df, input)
-    })
-    
-    output$strata_order_ui <- renderUI({
-      render_strata_order_input(ns, df, input$stratify_var)
-    })
+    strat_info <- stratification_server("strat", df)
     
     # -----------------------------------------------------------
     # Level order selections
@@ -110,8 +107,7 @@ two_way_anova_server <- function(id, filtered_data) {
         factor1_order = input$order1,
         factor2_var = input$factor2,
         factor2_order = input$order2,
-        stratify_var = input$stratify_var,
-        strata_order = input$strata_order
+        stratification = strat_info()
       )
     })
     

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -7,7 +7,10 @@ descriptive_ui <- function(id) {
   list(
     config = tagList(
       uiOutput(ns("inputs")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong(STRAT_SECTION_TITLE)),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show summary", width = "100%")),
@@ -25,7 +28,7 @@ descriptive_server <- function(id, filtered_data) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     df <- filtered_data
-    
+
     # ------------------------------------------------------------
     # Dynamic inputs
     # ------------------------------------------------------------
@@ -42,16 +45,7 @@ descriptive_server <- function(id, filtered_data) {
       )
     })
     
-    output$advanced_options <- renderUI({
-      tagList(
-        render_stratification_controls(ns, df, input),
-        uiOutput(ns("strata_order_ui"))
-      )
-    })
-    
-    output$strata_order_ui <- renderUI({
-      render_strata_order_input(ns, df, input$stratify_var)
-    })
+    strat_info <- stratification_server("strat", df)
     
     # ------------------------------------------------------------
     # Summary computation
@@ -63,16 +57,13 @@ descriptive_server <- function(id, filtered_data) {
       selected_vars <- unique(c(input$cat_vars, input$num_vars))
       validate(need(length(selected_vars) > 0, "Please select at least one variable."))
 
-      group_var <- if (is.null(input$stratify_var) || input$stratify_var == "None") NULL else input$stratify_var
-      if (!guard_stratification_levels(raw_data, group_var)) {
-        return(NULL)
-      }
-
+      strat_details <- strat_info()
+      group_var <- strat_details$var
       data_columns <- selected_vars
 
       if (!is.null(group_var)) {
         # keep ONLY selected levels, in the exact order; drop NA and unused levels
-        sel <- input$strata_order
+        sel <- strat_details$levels
         if (!is.null(sel) && length(sel) > 0) {
           local_data <- dplyr::filter(local_data, .data[[group_var]] %in% sel)
           local_data[[group_var]] <- factor(as.character(local_data[[group_var]]), levels = sel)
@@ -87,13 +78,6 @@ descriptive_server <- function(id, filtered_data) {
       data_columns <- data_columns[!is.na(data_columns) & nzchar(data_columns)]
       data_columns <- intersect(data_columns, names(local_data))
       local_data <- local_data[, data_columns, drop = FALSE]
-
-      if (!is.null(group_var) && !is.null(input$strata_order)) {
-        if (group_var %in% names(local_data)) {
-          local_data[[group_var]] <- factor(as.character(local_data[[group_var]]),
-                                            levels = input$strata_order)
-        }
-      }
 
       strata_levels <- if (!is.null(group_var) && group_var %in% names(local_data)) {
         levels(local_data[[group_var]])

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -8,7 +8,10 @@ ggpairs_ui <- function(id) {
     config = tagList(
       selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
       br(),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong(STRAT_SECTION_TITLE)),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show correlation matrix", width = "100%")),
@@ -27,13 +30,7 @@ ggpairs_server <- function(id, data_reactive) {
     ns <- session$ns
     df <- reactive(data_reactive())
 
-    output$advanced_options <- renderUI({
-      render_stratification_controls(ns, df, input)
-    })
-
-    output$strata_order_ui <- renderUI({
-      render_strata_order_input(ns, df, input$stratify_var)
-    })
+    strat_info <- stratification_server("strat", df)
 
     # ---- Update variable selector ----
     observe({
@@ -87,26 +84,21 @@ ggpairs_server <- function(id, data_reactive) {
         return()
       }
 
-      group_var <- input$stratify_var
-      if (is.null(group_var) || identical(group_var, "None") || identical(group_var, "")) {
-        group_var <- NULL
-      }
-
-      if (!is.null(group_var) && !guard_stratification_levels(data, group_var)) {
-        correlation_store(NULL)
-        return()
-      }
+      strat_details <- strat_info()
+      group_var <- strat_details$var
 
       strata_levels <- "Overall"
       if (!is.null(group_var) && group_var %in% names(data)) {
-        values <- data[[group_var]]
-        values <- values[!is.na(values)]
-        if (!is.null(input$strata_order) && length(input$strata_order) > 0) {
-          unique_values <- unique(as.character(values))
-          strata_levels <- input$strata_order[input$strata_order %in% unique_values]
-        } else {
+        levels <- strat_details$levels
+        if (is.null(levels) || length(levels) == 0) {
+          values <- data[[group_var]]
+          values <- values[!is.na(values)]
           strata_levels <- unique(as.character(values))
+        } else {
+          strata_levels <- levels
         }
+      } else {
+        group_var <- NULL
       }
 
       matrices <- list()
@@ -212,8 +204,14 @@ ggpairs_server <- function(id, data_reactive) {
       list(
         type = "pairwise_correlation",
         data = df,
-        group_var = reactive(input$stratify_var),
-        strata_order = reactive(input$strata_order),
+        group_var = reactive({
+          details <- strat_info()
+          details$var
+        }),
+        strata_order = reactive({
+          details <- strat_info()
+          details$levels
+        }),
         results = reactive(correlation_store())
       )
     })

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -15,7 +15,10 @@ regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FA
       uiOutput(ns("covar_selector")),
       if (engine == "lmm") uiOutput(ns("random_selector")),
       uiOutput(ns("interaction_select")),
-      uiOutput(ns("stratification_controls")),
+      tags$details(
+        tags$summary(strong(STRAT_SECTION_TITLE)),
+        stratification_ui("strat", ns)
+      ),
       hr(),
       uiOutput(ns("formula_preview")),
       br(),
@@ -36,6 +39,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
 
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+    strat_info <- stratification_server("strat", data)
 
     output$response_ui <- renderUI({
       req(data())
@@ -119,15 +123,6 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       reg_interactions_ui(ns, input$fixed, types$fac)
     })
 
-    output$stratification_controls <- renderUI({
-      req(data())
-      render_stratification_controls(ns, data, input)
-    })
-
-    output$strata_order_ui <- renderUI({
-      render_strata_order_input(ns, data, input$stratify_var)
-    })
-
     selected_responses <- reactive({
       if (allow_multi_response) {
         get_selected_responses(input)
@@ -135,28 +130,6 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         req(input$dep)
         input$dep
       }
-    })
-
-    get_stratification_info <- reactive({
-      req(data())
-      strat_var <- input$stratify_var
-      if (is.null(strat_var) || identical(strat_var, "None")) return(NULL)
-
-      df <- data()
-      if (is.null(df[[strat_var]])) return(NULL)
-
-      available_levels <- unique(as.character(stats::na.omit(df[[strat_var]])))
-      if (length(available_levels) == 0) return(NULL)
-
-      selected_levels <- input$strata_order
-      if (!is.null(selected_levels) && length(selected_levels) > 0) {
-        strata_levels <- selected_levels[selected_levels %in% available_levels]
-        if (length(strata_levels) == 0) strata_levels <- available_levels
-      } else {
-        strata_levels <- available_levels
-      }
-
-      list(var = strat_var, levels = strata_levels)
     })
 
     output$formula_preview <- renderUI({
@@ -177,12 +150,6 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       df <- data()
       responses <- selected_responses()
       req(length(responses) > 0)
-      
-      # ---- Validate stratification complexity ----
-      strat_var <- input$stratify_var
-      if (!guard_stratification_levels(df, strat_var)) {
-        return(NULL)
-      }
 
       rhs <- reg_compose_rhs(
         input$fixed,
@@ -192,7 +159,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         engine = engine
       )
 
-      strat_info <- get_stratification_info()
+      strat_details <- strat_info()
       safe_fit <- purrr::safely(reg_fit_model)
 
       fits <- list()
@@ -205,7 +172,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       primary_error <- NULL
 
       for (resp in responses) {
-        if (is.null(strat_info)) {
+        if (is.null(strat_details$var)) {
           result <- safe_fit(resp, rhs, df, engine = engine)
           entry <- list(
             stratified = FALSE,
@@ -236,8 +203,8 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
           strata_entries <- list()
           successful_strata <- list()
 
-          for (level in strat_info$levels) {
-            subset_data <- df[df[[strat_info$var]] == level, , drop = FALSE]
+          for (level in strat_details$levels) {
+            subset_data <- df[df[[strat_details$var]] == level, , drop = FALSE]
             if (nrow(subset_data) == 0) {
               msg <- paste0("No observations available for stratum '", level, "'.")
               strata_entries[[length(strata_entries) + 1]] <- list(
@@ -316,7 +283,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         error = primary_error,
         rhs = rhs,
         allow_multi = allow_multi_response,
-        stratification = strat_info
+        stratification = strat_details
       )
     })
 

--- a/R/ui_stratification.R
+++ b/R/ui_stratification.R
@@ -44,68 +44,132 @@ guard_stratification_levels <- function(data, stratify_var,
 }
 
 # ---------------------------------------------------------------
-# Stratification options panel (select strat variable + placeholder for order)
+# Stratification UI module (select + order controls)
 # ---------------------------------------------------------------
-render_stratification_controls <- function(ns, data, input,
-                                           section_title = "Advanced options",
-                                           stratify_label = "Stratify by:",
-                                           none_label = "None") {
-  df <- .resolve_data(data)
-  req(df)
-  
-  cat_cols <- names(df)[sapply(df, function(x) is.character(x) || is.factor(x))]
-  choices <- c(none_label, setdiff(unique(cat_cols), none_label))
-  
-  tags$details(
-    tags$summary(strong(section_title)),
-    selectInput(
-      ns("stratify_var"),
-      stratify_label,
-      choices = choices,
-      selected = none_label
-    ),
-    uiOutput(ns("strata_order_ui"))
-  )
-}
+STRAT_SECTION_TITLE <- "Advanced options"
+STRAT_CHOOSE_LABEL <- "Stratify by:"
+STRAT_NONE_LABEL <- "None"
+STRAT_ORDER_LABEL <- "Order of levels (first = reference):"
 
-# Backwards compat alias for ANOVA modules (legacy name)
-render_advanced_options <- render_stratification_controls
-
-# ---------------------------------------------------------------
-# Stratification order selector (shared across modules)
-# ---------------------------------------------------------------
-render_strata_order_input <- function(ns, data, strat_var,
-                                      input_id = "strata_order",
-                                      order_label = NULL) {
-  if (is.null(strat_var) || identical(strat_var, "None")) return(NULL)
-  
-  df <- .resolve_data(data)
-  if (is.null(df)) return(NULL)
-  if (nrow(df) == 0) return(NULL)
-  
-  values <- df[[strat_var]]
-  if (is.null(values)) return(NULL)
-  
-  if (is.factor(values)) {
-    strata_levels <- levels(values)
+stratification_ui <- function(id, ns = NULL) {
+  ns_fn <- if (is.null(ns)) {
+    NS(id)
+  } else if (is.function(ns)) {
+    function(x) ns(paste(id, x, sep = "-"))
   } else {
-    values <- values[!is.na(values)]
-    strata_levels <- unique(as.character(values))
+    NS(id)
   }
-  
-  if (length(strata_levels) == 0) return(NULL)
-  
-  if (is.null(order_label)) {
-    order_label <- "Order of levels (first = reference):"
-  }
-  
-  selectInput(
-    ns(input_id),
-    order_label,
-    choices = strata_levels,
-    selected = strata_levels,
-    multiple = TRUE
+
+  shiny::tagList(
+    shiny::uiOutput(ns_fn("stratify_var_ui")),
+    shiny::uiOutput(ns_fn("strata_order_ui"))
   )
 }
 
+stratification_server <- function(id, data) {
+  moduleServer(id, function(input, output, session) {
+    resolved_data <- reactive({
+      .resolve_data(data)
+    })
+
+    output$stratify_var_ui <- shiny::renderUI({
+      df <- resolved_data()
+
+      choices <- STRAT_NONE_LABEL
+      if (is.data.frame(df) && ncol(df) > 0) {
+        cat_cols <- names(df)[vapply(df, function(x) is.character(x) || is.factor(x), logical(1))]
+        cat_cols <- setdiff(unique(cat_cols), STRAT_NONE_LABEL)
+        if (length(cat_cols) > 0) {
+          choices <- c(STRAT_NONE_LABEL, cat_cols)
+        }
+      }
+
+      current <- isolate(input$stratify_var)
+      if (is.null(current) || !(current %in% choices)) {
+        current <- STRAT_NONE_LABEL
+      }
+
+      shiny::selectInput(
+        session$ns("stratify_var"),
+        STRAT_CHOOSE_LABEL,
+        choices = choices,
+        selected = current
+      )
+    })
+
+    strat_details <- reactive({
+      df <- resolved_data()
+      if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) {
+        return(list(var = NULL, levels = NULL, available_levels = NULL))
+      }
+
+      strat_var <- input$stratify_var
+      if (is.null(strat_var) || identical(strat_var, STRAT_NONE_LABEL) ||
+          !nzchar(strat_var) || !(strat_var %in% names(df))) {
+        return(list(var = NULL, levels = NULL, available_levels = NULL))
+      }
+
+      if (!guard_stratification_levels(df, strat_var, session = session)) {
+        shiny::updateSelectInput(session, "stratify_var", selected = STRAT_NONE_LABEL)
+        return(list(var = NULL, levels = NULL, available_levels = NULL))
+      }
+
+      values <- df[[strat_var]]
+      if (is.factor(values)) {
+        available_levels <- levels(values)
+      } else {
+        values <- values[!is.na(values)]
+        available_levels <- unique(as.character(values))
+      }
+
+      available_levels <- available_levels[!is.na(available_levels)]
+
+      if (length(available_levels) == 0) {
+        return(list(var = strat_var, levels = character(0), available_levels = character(0)))
+      }
+
+      selected_levels <- input$strata_order
+      if (!is.null(selected_levels) && length(selected_levels) > 0) {
+        selected_levels <- selected_levels[selected_levels %in% available_levels]
+      }
+
+      if (is.null(selected_levels) || length(selected_levels) == 0) {
+        selected_levels <- available_levels
+      }
+
+      list(
+        var = strat_var,
+        levels = selected_levels,
+        available_levels = available_levels
+      )
+    })
+
+    output$strata_order_ui <- shiny::renderUI({
+      details <- strat_details()
+      strat_var <- details$var
+      if (is.null(strat_var)) return(NULL)
+
+      available_levels <- details$available_levels
+      if (is.null(available_levels) || length(available_levels) == 0) return(NULL)
+
+      selected_levels <- details$levels
+      if (is.null(selected_levels) || length(selected_levels) == 0) {
+        selected_levels <- available_levels
+      }
+
+      shiny::selectInput(
+        session$ns("strata_order"),
+        STRAT_ORDER_LABEL,
+        choices = available_levels,
+        selected = selected_levels,
+        multiple = TRUE
+      )
+    })
+
+    reactive({
+      details <- strat_details()
+      list(var = details$var, levels = details$levels)
+    })
+  })
+}
 


### PR DESCRIPTION
## Summary
- embed the shared stratification controls directly in each analysis module's advanced options UI section
- simplify module servers by removing renderUI plumbing now that stratification_ui returns the necessary outputs
- return the tag list from stratification_ui so callers can include it inline with other advanced widgets

## Testing
- Not run (Rscript unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_6908bb626860832b8b636ad5fb239174