### PR TITLE
Embed stratification controls directly in analysis UIs

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -8,7 +8,11 @@ one_way_anova_ui <- function(id) {
     config = tagList(
       uiOutput(ns("inputs")),
       uiOutput(ns("level_order")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong("Advanced options")),
+        br(),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show results", width = "100%")),
@@ -54,14 +58,6 @@ one_way_anova_server <- function(id, filtered_data) {
       render_response_inputs(ns, df(), input)
     })
     
-    output$stratification_controls <- stratification_ui(ns("strat"))
-    output$advanced_options <- renderUI({
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        br(),
-        uiOutput(ns("stratification_controls"))
-      )
-    })
     strat_info <- stratification_server("strat", df)
     
     # -----------------------------------------------------------

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -9,7 +9,11 @@ two_way_anova_ui <- function(id) {
       uiOutput(ns("inputs")),
       uiOutput(ns("level_order_1")),
       uiOutput(ns("level_order_2")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong("Advanced options")),
+        br(),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show results", width = "100%")),
@@ -61,14 +65,6 @@ two_way_anova_server <- function(id, filtered_data) {
       render_response_selector(ns, df, input)
     })
     
-    output$stratification_controls <- stratification_ui(ns("strat"))
-    output$advanced_options <- renderUI({
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        br(),
-        uiOutput(ns("stratification_controls"))
-      )
-    })
     strat_info <- stratification_server("strat", df)
     
     # -----------------------------------------------------------

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -7,7 +7,11 @@ descriptive_ui <- function(id) {
   list(
     config = tagList(
       uiOutput(ns("inputs")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong("Advanced options")),
+        br(),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show summary", width = "100%")),
@@ -42,14 +46,6 @@ descriptive_server <- function(id, filtered_data) {
       )
     })
     
-    output$stratification_controls <- stratification_ui(ns("strat"))
-    output$advanced_options <- renderUI({
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        br(),
-        uiOutput(ns("stratification_controls"))
-      )
-    })
     strat_info <- stratification_server("strat", df)
     
     # ------------------------------------------------------------

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -8,7 +8,11 @@ ggpairs_ui <- function(id) {
     config = tagList(
       selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
       br(),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong("Advanced options")),
+        br(),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run"), "Show correlation matrix", width = "100%")),
@@ -27,14 +31,6 @@ ggpairs_server <- function(id, data_reactive) {
     ns <- session$ns
     df <- reactive(data_reactive())
 
-    output$stratification_controls <- stratification_ui(ns("strat"))
-    output$advanced_options <- renderUI({
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        br(),
-        uiOutput(ns("stratification_controls"))
-      )
-    })
     strat_info <- stratification_server("strat", df)
 
     # ---- Update variable selector ----

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -8,7 +8,11 @@ pca_ui <- function(id) {
     config = tagList(
       selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
       br(),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong("Advanced options")),
+        br(),
+        stratification_ui("strat", ns)
+      ),
       br(),
       fluidRow(
         column(6, actionButton(ns("run_pca"), "Show PCA summary", width = "100%")),
@@ -33,14 +37,6 @@ pca_server <- function(id, filtered_data) {
       updateSelectInput(session, "vars", choices = num_vars, selected = num_vars)
     })
 
-    output$stratification_controls <- stratification_ui(ns("strat"))
-    output$advanced_options <- renderUI({
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        br(),
-        uiOutput(ns("stratification_controls"))
-      )
-    })
     strat_info <- stratification_server("strat", df)
 
     run_pca_on_subset <- function(subset_data, selected_vars) {

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -15,7 +15,11 @@ regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FA
       uiOutput(ns("covar_selector")),
       if (engine == "lmm") uiOutput(ns("random_selector")),
       uiOutput(ns("interaction_select")),
-      uiOutput(ns("advanced_options")),
+      tags$details(
+        tags$summary(strong("Advanced options")),
+        br(),
+        stratification_ui("strat", ns)
+      ),
       hr(),
       uiOutput(ns("formula_preview")),
       br(),
@@ -118,15 +122,6 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       req(data())
       types <- reg_detect_types(data())
       reg_interactions_ui(ns, input$fixed, types$fac)
-    })
-
-    output$stratification_controls <- stratification_ui(ns("strat"))
-    output$advanced_options <- renderUI({
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        br(),
-        uiOutput(ns("stratification_controls"))
-      )
     })
 
     selected_responses <- reactive({

--- a/R/submodule_stratification.R
+++ b/R/submodule_stratification.R
@@ -15,13 +15,11 @@ stratification_ui <- function(id, ns = NULL) {
   } else {
     NS(id)
   }
-  
-  shiny::renderUI({
-    shiny::tagList(
-      shiny::uiOutput(ns_fn("stratify_var_ui")),
-      shiny::uiOutput(ns_fn("strata_order_ui"))
-    )
-  })
+
+  shiny::tagList(
+    shiny::uiOutput(ns_fn("stratify_var_ui")),
+    shiny::uiOutput(ns_fn("strata_order_ui"))
+  )
 }
 
 


### PR DESCRIPTION
## Summary
- embed the stratification controls within each analysis module's UI so the advanced options expander is constructed alongside other inputs
- update the shared stratification UI helper to return static UI elements for use in module layouts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6908cba43a00832b81ca58a1200f621a