### PR TITLE
Standardize analysis module outputs

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -120,7 +120,77 @@ one_way_anova_server <- function(id, filtered_data) {
     # Render model summaries + download buttons (shared helper)
     # -----------------------------------------------------------
     bind_anova_outputs(ns, output, models)
-    
-    return(models)
+
+    df_final <- reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+      mod$data_used
+    })
+
+    model_fit <- reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+      mod$models
+    })
+
+    compiled_results <- reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+      compile_anova_results(mod)
+    })
+
+    summary_table <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$summary
+    })
+
+    posthoc_results <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$posthoc
+    })
+
+    effect_table <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$effects
+    })
+
+    error_table <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$errors
+    })
+
+    reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+
+      data_used <- df_final()
+
+      list(
+        analysis_type = "ANOVA",
+        data_used = data_used,
+        model = model_fit(),
+        summary = summary_table(),
+        posthoc = posthoc_results(),
+        effects = effect_table(),
+        stats = if (!is.null(data_used)) list(n = nrow(data_used), vars = names(data_used)) else NULL,
+        metadata = list(
+          responses = mod$responses,
+          strata = mod$strata,
+          factors = mod$factors,
+          orders = mod$orders,
+          errors = error_table()
+        ),
+        type = "oneway_anova",
+        models = model_fit(),
+        responses = mod$responses,
+        strata = mod$strata,
+        factors = mod$factors,
+        orders = mod$orders
+      )
+    })
   })
 }

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -144,7 +144,77 @@ two_way_anova_server <- function(id, filtered_data) {
     # Render model summaries + downloads (shared helper)
     # -----------------------------------------------------------
     bind_anova_outputs(ns, output, models)
-    
-    return(models)
+
+    df_final <- reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+      mod$data_used
+    })
+
+    model_fit <- reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+      mod$models
+    })
+
+    compiled_results <- reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+      compile_anova_results(mod)
+    })
+
+    summary_table <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$summary
+    })
+
+    posthoc_results <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$posthoc
+    })
+
+    effect_table <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$effects
+    })
+
+    error_table <- reactive({
+      res <- compiled_results()
+      if (is.null(res)) return(NULL)
+      res$errors
+    })
+
+    reactive({
+      mod <- models()
+      if (is.null(mod)) return(NULL)
+
+      data_used <- df_final()
+
+      list(
+        analysis_type = "ANOVA",
+        data_used = data_used,
+        model = model_fit(),
+        summary = summary_table(),
+        posthoc = posthoc_results(),
+        effects = effect_table(),
+        stats = if (!is.null(data_used)) list(n = nrow(data_used), vars = names(data_used)) else NULL,
+        metadata = list(
+          responses = mod$responses,
+          strata = mod$strata,
+          factors = mod$factors,
+          orders = mod$orders,
+          errors = error_table()
+        ),
+        type = "twoway_anova",
+        models = model_fit(),
+        responses = mod$responses,
+        strata = mod$strata,
+        factors = mod$factors,
+        orders = mod$orders
+      )
+    })
   })
 }

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -122,23 +122,70 @@ descriptive_server <- function(id, filtered_data) {
     # ------------------------------------------------------------
     # Return full model info
     # ------------------------------------------------------------
-    return(reactive({
+    df_final <- reactive({
       details <- summary_data()
-      if (is.null(details)) {
-        return(NULL)
-      }
+      if (is.null(details)) return(NULL)
+      details$processed_data
+    })
+
+    model_fit <- reactive(NULL)
+
+    summary_table <- reactive({
+      details <- summary_data()
+      if (is.null(details)) return(NULL)
+      details$summary
+    })
+
+    posthoc_results <- reactive(NULL)
+
+    effect_table <- reactive(NULL)
+
+    selected_vars_reactive <- reactive({
+      details <- summary_data()
+      if (is.null(details)) return(NULL)
+      details$selected_vars
+    })
+
+    group_var_reactive <- reactive({
+      details <- summary_data()
+      if (is.null(details)) return(NULL)
+      details$group_var
+    })
+
+    strata_levels_reactive <- reactive({
+      details <- summary_data()
+      if (is.null(details)) return(NULL)
+      details$strata_levels
+    })
+
+    reactive({
+      details <- summary_data()
+      if (is.null(details)) return(NULL)
+
+      data_used <- df_final()
 
       list(
+        analysis_type = "DESCRIPTIVE",
+        data_used = data_used,
+        model = model_fit(),
+        summary = summary_table(),
+        posthoc = posthoc_results(),
+        effects = effect_table(),
+        stats = if (!is.null(data_used)) list(n = nrow(data_used), vars = names(data_used)) else NULL,
+        metadata = list(
+          selected_vars = details$selected_vars,
+          group_var = details$group_var,
+          strata_levels = details$strata_levels
+        ),
         type = "descriptive",
         data = df,
-        summary = reactive({ details <- summary_data(); req(details); details$summary }),
-        selected_vars = reactive({ details <- summary_data(); req(details); details$selected_vars }),
-        group_var = reactive({ details <- summary_data(); req(details); details$group_var }),
-        processed_data = reactive({ details <- summary_data(); req(details); details$processed_data }),
-        strata_levels = reactive({ details <- summary_data(); req(details); details$strata_levels })
+        processed_data = df_final,
+        selected_vars = selected_vars_reactive,
+        group_var = group_var_reactive,
+        strata_levels = strata_levels_reactive
       )
-    }))
-    
+    })
+
   })
 }
 


### PR DESCRIPTION
## Summary
- return a consistent structured list from descriptive, ANOVA, correlation, PCA, and regression analysis servers
- add shared helpers to build tidy ANOVA and regression tables plus metadata for the unified payloads
- adjust the analysis coordinator to propagate standardized `analysis_type` data without altering module logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908d8a74748832b8fa51774be0e94d8