### PR TITLE
Refactor grid layout validation with user feedback

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -822,10 +822,22 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
         rows_input = effective_input("strata_rows"),
         cols_input = effective_input("strata_cols")
       )
-      
+
+      if (!isTRUE(layout$valid)) {
+        return(list(
+          plot = NULL,
+          layout = list(
+            strata = list(rows = layout$nrow, cols = layout$ncol, valid = layout$valid, message = layout$message),
+            responses = list(nrow = 1L, ncol = 1L, valid = TRUE, message = NULL)
+          ),
+          has_strata = has_strata,
+          n_responses = 0L
+        ))
+      }
+
       max_strata_rows <- max(max_strata_rows, layout$nrow)
       max_strata_cols <- max(max_strata_cols, layout$ncol)
-      
+
       combined <- patchwork::wrap_plots(
         plotlist = strata_plot_list,
         nrow = layout$nrow,
@@ -869,7 +881,19 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
     rows_input = effective_input("resp_rows"),
     cols_input = effective_input("resp_cols")
   )
-  
+
+  if (!isTRUE(resp_layout$valid)) {
+    return(list(
+      plot = NULL,
+      layout = list(
+        strata = list(rows = max_strata_rows, cols = max_strata_cols, valid = TRUE, message = NULL),
+        responses = resp_layout
+      ),
+      has_strata = has_strata,
+      n_responses = length(response_plots)
+    ))
+  }
+
   final_plot <- if (length(response_plots) == 1) {
     response_plots[[1]]
   } else {
@@ -884,7 +908,7 @@ build_anova_plot_info <- function(data, info, effective_input, line_colors = NUL
   list(
     plot = final_plot,
     layout = list(
-      strata = list(rows = max_strata_rows, cols = max_strata_cols),
+      strata = list(rows = max_strata_rows, cols = max_strata_cols, valid = TRUE, message = NULL),
       responses = resp_layout
     ),
     has_strata = has_strata,

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -44,10 +44,7 @@ visualize_categorical_barplots_ui <- function(id) {
 
 visualize_categorical_barplots_plot_ui <- function(id) {
   ns <- NS(id)
-  div(
-    class = "ta-plot-container",
-    plotOutput(ns("plot"), width = "100%", height = "auto")
-  )
+  uiOutput(ns("plot_container"))
 }
 
 visualize_categorical_barplots_server <- function(id, filtered_data, summary_info, is_active = NULL) {
@@ -142,7 +139,7 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       req(module_active())
       info <- plot_info()
       layout <- info$layout
-      if (is.null(layout)) {
+      if (is.null(layout) || !isTRUE(layout$valid)) {
         list(w = plot_width(), h = plot_height())
       } else {
         list(
@@ -151,6 +148,19 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         )
       }
     })
+
+    output$plot_container <- renderUI({
+      req(module_active())
+      info <- plot_info()
+      layout <- info$layout
+      container <- function(content) {
+        div(class = "ta-plot-container", content)
+      }
+      if (!is.null(layout) && !isTRUE(layout$valid)) {
+        return(container(div(class = "alert alert-warning", layout$message)))
+      }
+      container(plotOutput(ns("plot"), width = "100%", height = "auto"))
+    })
     
     
     output$download_plot <- downloadHandler(
@@ -158,6 +168,8 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       content  = function(file) {
         req(module_active())
         info <- plot_info()
+        layout <- info$layout
+        req(is.null(layout) || isTRUE(layout$valid))
         req(info$plot)
         s <- plot_size()
         ggplot2::ggsave(
@@ -176,6 +188,8 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
     output$plot <- renderPlot({
       req(module_active())
       info <- plot_info()
+      layout <- info$layout
+      if (is.null(layout) || !isTRUE(layout$valid)) return(NULL)
       print(info$plot)
     },
     width = function() {
@@ -323,15 +337,23 @@ build_descriptive_categorical_plot <- function(df,
     rows_input = suppressWarnings(as.numeric(nrow_input)),
     cols_input = suppressWarnings(as.numeric(ncol_input))
   )
-  
+
+  if (!isTRUE(layout$valid)) {
+    return(list(
+      plot = NULL,
+      layout = layout,
+      panels = length(plots)
+    ))
+  }
+
   combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
     patchwork::plot_annotation(
       theme = theme(plot.title = element_text(size = 16, face = "bold"))
     )
-  
+
   list(
     plot = combined,
-    layout = list(nrow = layout$nrow, ncol = layout$ncol),
+    layout = layout,
     panels = length(plots)
   )
 }

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -36,10 +36,7 @@ visualize_missing_ui <- function(id) {
 
 metric_plot_ui <- function(id) {
   ns <- NS(id)
-  div(
-    class = "ta-plot-container",
-    plotOutput(ns("plot"), width = "100%", height = "auto")
-  )
+  uiOutput(ns("plot_container"))
 }
 
 visualize_cv_plot_ui <- function(id) {
@@ -208,6 +205,8 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
                                  y_label, title, filename_prefix, is_active = NULL) {
   moduleServer(id, function(input, output, session) {
 
+    ns <- session$ns
+
     layout_state <- initialize_layout_state(input, session)
 
     plot_width <- reactive({
@@ -270,15 +269,17 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
         cols_input = layout_state$effective_input("resp_cols")
       )
 
-      n_rows <- layout$nrow
-      n_cols <- layout$ncol
+      if (!isTRUE(layout$valid)) {
+        sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", layout)
+        return(list(plot = NULL, layout = layout))
+      }
 
-      plot <- build_metric_plot(metric_info, y_label, title, n_rows, n_cols)
-      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", list(nrow = n_rows, ncol = n_cols))
+      plot <- build_metric_plot(metric_info, y_label, title, layout$nrow, layout$ncol)
+      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", layout)
 
       list(
         plot = plot,
-        layout = list(nrow = n_rows, ncol = n_cols)
+        layout = layout
       )
     })
 
@@ -287,14 +288,28 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
     plot_size <- reactive({
       req(module_active())
       details <- plot_details()
-      if (is.null(details$layout)) {
+      layout <- details$layout
+      if (is.null(layout) || !isTRUE(layout$valid)) {
         list(w = plot_width(), h = plot_height())
       } else {
         list(
-          w = plot_width()  * details$layout$ncol,
-          h = plot_height() * details$layout$nrow
+          w = plot_width()  * layout$ncol,
+          h = plot_height() * layout$nrow
         )
       }
+    })
+
+    output$plot_container <- renderUI({
+      req(module_active())
+      details <- plot_details()
+      layout <- details$layout
+      container <- function(content) {
+        div(class = "ta-plot-container", content)
+      }
+      if (!is.null(layout) && !isTRUE(layout$valid)) {
+        return(container(div(class = "alert alert-warning", layout$message)))
+      }
+      container(plotOutput(ns("plot"), width = "100%", height = "auto"))
     })
 
     output$download_plot <- downloadHandler(
@@ -302,6 +317,8 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       content = function(file) {
         req(module_active())
         details <- plot_details()
+        layout <- details$layout
+        req(is.null(layout) || isTRUE(layout$valid))
         req(details$plot)
         size <- plot_size()
         ggplot2::ggsave(
@@ -320,6 +337,8 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
     output$plot <- renderPlot({
       req(module_active())
       details <- plot_details()
+      layout <- details$layout
+      if (is.null(layout) || !isTRUE(layout$valid)) return(NULL)
       validate(need(!is.null(details$plot), "No plot available."))
       print(details$plot)
     },

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -43,16 +43,14 @@ visualize_numeric_boxplots_ui <- function(id) {
 
 visualize_numeric_boxplots_plot_ui <- function(id) {
   ns <- NS(id)
-  div(
-    class = "ta-plot-container",
-    plotOutput(ns("plot"), width = "100%", height = "auto")
-  )
+  uiOutput(ns("plot_container"))
 }
 
 
 visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, is_active = NULL) {
   moduleServer(id, function(input, output, session) {
 
+    ns <- session$ns
     layout_state <- initialize_layout_state(input, session)
 
     resolve_input_value <- function(x) {
@@ -113,7 +111,7 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       req(module_active())
       info <- plot_info()
       layout <- info$layout
-      if (is.null(layout)) {
+      if (is.null(layout) || !isTRUE(layout$valid)) {
         list(w = plot_width(), h = plot_height())
       } else {
         list(
@@ -122,6 +120,19 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         )
       }
     })
+
+    output$plot_container <- renderUI({
+      req(module_active())
+      info <- plot_info()
+      layout <- info$layout
+      container <- function(content) {
+        div(class = "ta-plot-container", content)
+      }
+      if (!is.null(layout) && !isTRUE(layout$valid)) {
+        return(container(div(class = "alert alert-warning", layout$message)))
+      }
+      container(plotOutput(ns("plot"), width = "100%", height = "auto"))
+    })
     
     
     output$download_plot <- downloadHandler(
@@ -129,6 +140,8 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       content  = function(file) {
         req(module_active())
         info <- plot_info()
+        layout <- info$layout
+        req(is.null(layout) || isTRUE(layout$valid))
         req(info$plot)
         s <- plot_size()
         ggplot2::ggsave(
@@ -147,6 +160,8 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
     output$plot <- renderPlot({
       req(module_active())
       info <- plot_info()
+      layout <- info$layout
+      if (is.null(layout) || !isTRUE(layout$valid)) return(NULL)
       print(info$plot)
     },
     width = function() {
@@ -226,15 +241,23 @@ build_descriptive_numeric_boxplot <- function(df,
     rows_input = suppressWarnings(as.numeric(nrow_input)),
     cols_input = suppressWarnings(as.numeric(ncol_input))
   )
-  
+
+  if (!isTRUE(layout$valid)) {
+    return(list(
+      plot = NULL,
+      layout = layout,
+      panels = length(plots)
+    ))
+  }
+
   combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
     patchwork::plot_annotation(
       theme = theme(plot.title = element_text(size = 16, face = "bold"))
     )
-  
+
   list(
     plot = combined,
-    layout = list(nrow = layout$nrow, ncol = layout$ncol),
+    layout = layout,
     panels = length(plots)
   )
 }

--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -109,14 +109,14 @@ resolve_grid_layout <- function(n_items, rows_input = NULL, cols_input = NULL) {
   # --- Validate number of items ---
   n_items <- suppressWarnings(as.integer(n_items[1]))
   if (is.na(n_items) || n_items <= 0) n_items <- 1L
-  
+
   # --- Extract numeric inputs ---
   rows_raw <- resolve_grid_value(rows_input)
   cols_raw <- resolve_grid_value(cols_input)
-  
+
   rows <- rows_raw
   cols <- cols_raw
-  
+
   # --- Compute sensible defaults ---
   if (is.na(rows) && is.na(cols)) {
     # automatic roughly-square layout
@@ -139,26 +139,32 @@ resolve_grid_layout <- function(n_items, rows_input = NULL, cols_input = NULL) {
       cols <- ceiling(n_items / rows)
     }
   }
-  
+
   # --- Clamp minimum values ---
   rows <- max(1L, rows)
   cols <- max(1L, cols)
-  
-  # --- Handle too-small grids safely ---
-  if (rows * cols < n_items) {
-    shiny::showNotification(
-      sprintf("⚠️ Grid %dx%d too small for %d subplots — auto-adjusting layout.",
-              rows, cols, n_items),
-      type = "warning",
-      duration = 6
-    )
-    # Expand automatically until it fits all subplots
-    while (rows * cols < n_items) {
-      if (cols <= rows) cols <- cols + 1L else rows <- rows + 1L
-    }
+
+  capacity <- rows * cols
+
+  if (capacity < n_items) {
+    return(list(
+      nrow = rows,
+      ncol = cols,
+      valid = FALSE,
+      message = sprintf("⚠️ Grid %dx%d too small for %d subplots.", rows, cols, n_items)
+    ))
   }
-  
-  list(nrow = rows, ncol = cols)
+
+  if (capacity > n_items) {
+    return(list(
+      nrow = rows,
+      ncol = cols,
+      valid = FALSE,
+      message = sprintf("⚠️ Grid %dx%d too large for %d subplots.", rows, cols, n_items)
+    ))
+  }
+
+  list(nrow = rows, ncol = cols, valid = TRUE, message = NULL)
 }
 
 

--- a/R/pairwise_correlation_visualize.R
+++ b/R/pairwise_correlation_visualize.R
@@ -22,7 +22,7 @@ visualize_ggpairs_ui <- function(id) {
     mainPanel(
       width = 8,
       h4("Plots"),
-      plotOutput(ns("plot"), height = "auto")
+      uiOutput(ns("plot_ui"))
     )
   )
 }
@@ -69,9 +69,26 @@ visualize_ggpairs_server <- function(id, filtered_data, model_fit) {
       active(handle)
     }, ignoreNULL = FALSE)
 
+    output$plot_ui <- renderUI({
+      h <- active()
+      container <- function(content) {
+        div(class = "ta-plot-container", content)
+      }
+      if (is.null(h)) {
+        return(container(div("Run the pairwise correlation analysis to generate plots.")))
+      }
+      layout <- h$layout()
+      if (!is.null(layout) && !isTRUE(layout$valid)) {
+        return(container(div(class = "alert alert-warning", layout$message)))
+      }
+      container(plotOutput(ns("plot"), height = "auto"))
+    })
+
     output$plot <- renderPlot({
       h <- active()
       req(h)
+      layout <- h$layout()
+      if (!is.null(layout) && !isTRUE(layout$valid)) return(NULL)
       plot_obj <- h$plot()
       validate(need(!is.null(plot_obj), "No plot available."))
       print(plot_obj)


### PR DESCRIPTION
## Summary
- update `resolve_grid_layout()` to report validity and user-facing messages instead of auto-adjusting grids
- wrap descriptive visualization outputs with warning UI when grid settings do not match subplot counts
- propagate grid validation through ANOVA, PCA, and pairwise correlation modules so plot areas display inline alerts when invalid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a18e79740832b84aeccc413f4c052