### PR TITLE
Remove grid control synchronization behavior

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -127,7 +127,6 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         fill_colors = custom_colors()
       )
       validate(need(!is.null(out), "No categorical variables available for plotting."))
-      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", out$layout)
       out
     })
 

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -269,12 +269,10 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       )
 
       if (!isTRUE(layout$valid)) {
-        sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", layout)
         return(list(plot = NULL, layout = layout))
       }
 
       plot <- build_metric_plot(metric_info, y_label, title, layout$nrow, layout$ncol)
-      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", layout)
 
       list(
         plot = plot,

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -100,7 +100,6 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       )
 
       validate(need(!is.null(out), "No numeric variables available for plotting."))
-      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", out$layout)
       out
     })
 

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -81,10 +81,6 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       )
       validate(need(!is.null(out), "No numeric variables available for plotting."))
 
-      n_panels <- if (is.null(out$panels)) 1L else max(1L, suppressWarnings(as.integer(out$panels)))
-      max_val <- 10L
-
-      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", out$layout, max_value = max_val)
       out
     })
 

--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -62,39 +62,6 @@ initialize_layout_state <- function(input, session) {
   )
 }
 
-sync_grid_controls <- function(layout_state,
-                               input,
-                               session,
-                               rows_name,
-                               cols_name,
-                               layout,
-                               max_value = 10L) {
-  if (is.null(layout)) {
-    return(invisible(NULL))
-  }
-
-  update_control <- function(name, target) {
-    if (is.null(name) || is.null(target) || !is.finite(target)) return()
-
-    target <- as.integer(max(1L, min(max_value, round(target))))
-
-    if (isTRUE(shiny::isolate(layout_state$manual[[name]]))) {
-      return()
-    }
-
-    current <- shiny::isolate(input[[name]])
-    if (isTRUE(!identical(as.integer(current), target))) {
-      layout_state$suppress[[name]] <- TRUE
-      updateNumericInput(session, name, value = target, min = 1, max = max_value)
-    }
-  }
-
-  update_control(rows_name, layout$nrow)
-  update_control(cols_name, layout$ncol)
-
-  invisible(NULL)
-}
-
 observe_layout_synchronization <- function(plot_info_reactive, layout_state, session) {
   observeEvent(plot_info_reactive(), {
     plot_info_reactive()

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -174,8 +174,6 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
         cols_input = layout_state$effective_input("resp_cols")
       )
 
-      sync_grid_controls(layout_state, input, session, "resp_rows", "resp_cols", layout)
-
       if (!isTRUE(layout$valid)) {
         return(list(plot = NULL, layout = layout))
       }

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -389,8 +389,6 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
         cols_input = layout_state$effective_input("strata_cols")
       )
 
-      sync_grid_controls(layout_state, input, session, "strata_rows", "strata_cols", layout)
-
       if (!isTRUE(layout$valid)) {
         return(list(
           plot = NULL,


### PR DESCRIPTION
## Summary
- remove the `sync_grid_controls` helper from the visualization layout module
- stop calling the helper so layout inputs no longer update each other automatically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a2018590c832b869b57b1c782add9