### PR TITLE
Adjust color dropdown UI behavior

### DIFF
--- a/R/custom_widgets.R
+++ b/R/custom_widgets.R
@@ -15,51 +15,95 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
                                  ncol = 4, selected = NULL) {
   selected_color <- if (is.null(selected)) palette[1] else selected
 
+  cell_size <- 32
+  gap_size <- 6
+  padding_size <- 6
+  button_height <- cell_size + (2 * padding_size)
+  dropdown_width <- cell_size * ncol + gap_size * (ncol - 1) + 2 * padding_size
+  dropdown_top <- button_height + 4
+
   tagList(
     tags$style(HTML(sprintf("
-      .color-dropdown {
-        position: relative;
-        display: inline-block;
-        width: 150px;
-        user-select: none;
-      }
-      .color-dropdown-button {
-        width: 100%%;
-        height: 32px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      .color-dropdown-grid {
-        display: none;
-        position: absolute;
-        top: 36px;
-        left: 0;
-        z-index: 999;
-        background: white;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        padding: 4px;
-        display: grid;
-        grid-template-columns: repeat(%d, 28px);
-        gap: 2px;
-      }
-      .color-cell {
-        width: 26px; height: 26px;
-        border-radius: 4px;
-        cursor: pointer;
-        border: 1px solid #ccc;
-      }
-      .color-cell:hover {
-        transform: scale(1.1);
-      }
-    ", ncol))),
+        .color-dropdown {
+          position: relative;
+          display: inline-block;
+          user-select: none;
+          width: %dpx;
+        }
+        .color-dropdown-button {
+          width: 100%%;
+          border: 1px solid #ccc;
+          border-radius: 6px;
+          padding: %dpx;
+          background-color: #fff;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: %dpx;
+          cursor: pointer;
+          box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+        }
+        .color-dropdown-swatch {
+          flex: 0 0 %dpx;
+          width: %dpx;
+          height: %dpx;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          box-sizing: border-box;
+        }
+        .color-dropdown-icon {
+          font-size: 10px;
+          color: #666;
+        }
+        .color-dropdown-grid {
+          display: none;
+          position: absolute;
+          top: %dpx;
+          left: 0;
+          z-index: 999;
+          background: #fff;
+          border: 1px solid #ccc;
+          border-radius: 6px;
+          padding: %dpx;
+          box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+          width: %dpx;
+          grid-template-columns: repeat(%d, %dpx);
+          gap: %dpx;
+          box-sizing: border-box;
+        }
+        .color-dropdown-grid.open {
+          display: grid;
+        }
+        .color-cell {
+          width: %dpx;
+          height: %dpx;
+          border-radius: 4px;
+          cursor: pointer;
+          border: 1px solid #ccc;
+          box-sizing: border-box;
+          transition: transform 0.1s ease;
+        }
+        .color-cell:hover {
+          transform: scale(1.05);
+        }
+      ",
+      dropdown_width, padding_size, gap_size, cell_size, cell_size, cell_size,
+      dropdown_top, padding_size, dropdown_width, ncol, cell_size, gap_size,
+      cell_size, cell_size
+    ))),
     tags$div(
       class = "color-dropdown",
       tags$div(
         id = ns(paste0(id, "_button")),
         class = "color-dropdown-button",
-        style = sprintf("background-color:%s;", selected_color)
+        tags$span(
+          class = "color-dropdown-swatch",
+          style = sprintf("background-color:%s;", selected_color)
+        ),
+        tags$span(
+          class = "color-dropdown-icon",
+          HTML("&#9662;")
+        )
       ),
       tags$div(
         id = ns(paste0(id, "_grid")),
@@ -69,9 +113,11 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
             class = "color-cell",
             title = col,
             style = sprintf("background-color:%s;", col),
-            onclick = sprintf("
-              $('#%s_button').css('background-color','%s');
-              $('#%s_grid').hide();
+            onclick = sprintf(
+              "
+              var button = $('#%s_button');
+              button.find('.color-dropdown-swatch').css('background-color','%s');
+              $('#%s_grid').removeClass('open');
               Shiny.setInputValue('%s','%s',{priority:'event'});
             ", ns(id), col, ns(id), ns(id), col)
           )
@@ -79,16 +125,18 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
       )
     ),
     tags$script(HTML(sprintf("
-      $('#%s_button').on('click', function(e){
-        e.stopPropagation();
-        var grid = $('#%s_grid');
-        $('.color-dropdown-grid').not(grid).hide();
-        grid.toggle();
-      });
-      $(document).on('click', function(){
-        $('.color-dropdown-grid').hide();
-      });
-      Shiny.setInputValue('%s','%s',{priority:'event'});
-    ", ns(id), ns(id), ns(id), selected_color)))
+        $('#%s_button').on('click', function(e){
+          e.stopPropagation();
+          var grid = $('#%s_grid');
+          $('.color-dropdown-grid').not(grid).removeClass('open');
+          grid.toggleClass('open');
+        });
+        $(document).on('click', function(){
+          $('.color-dropdown-grid').removeClass('open');
+        });
+        Shiny.setInputValue('%s','%s',{priority:'event'});
+      ",
+      ns(id), ns(id), ns(id), selected_color
+    )))
   )
 }


### PR DESCRIPTION
## Summary
- ensure the custom color dropdown grid stays collapsed until the color swatch is clicked
- align the dropdown width with the palette grid and render the selected color inside a square swatch
- update the JavaScript toggle logic to use a CSS class so the grid cleanly opens and closes

## Testing
- Not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690a5ba74408832b910d4e4d9d4fe271