### PR TITLE
Preserve user overrides for grid layout inputs

### DIFF
--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -81,38 +81,57 @@ basic_grid_layout <- function(rows = NULL,
   )
 }
 
-needs_numeric_update <- function(current_value, target_value) {
+numeric_sync_state <- function(session) {
+  state <- session$userData$ta_numeric_sync_state
+  if (is.null(state) || !is.environment(state)) {
+    state <- new.env(parent = emptyenv())
+    session$userData$ta_numeric_sync_state <- state
+  }
+  state
+}
+
+sync_numeric_input <- function(session, input_id, current_value, target_value) {
   if (is.null(target_value) || length(target_value) == 0) {
-    return(FALSE)
+    return(invisible(FALSE))
   }
 
   target_int <- suppressWarnings(as.integer(target_value[1]))
   if (is.na(target_int)) {
-    return(FALSE)
-  }
-
-  if (is.null(current_value) || length(current_value) == 0) {
-    return(TRUE)
-  }
-
-  current_int <- suppressWarnings(as.integer(current_value[1]))
-  if (is.na(current_int)) {
-    return(TRUE)
-  }
-
-  !identical(current_int, target_int)
-}
-
-sync_numeric_input <- function(session, input_id, current_value, target_value) {
-  if (!needs_numeric_update(current_value, target_value)) {
     return(invisible(FALSE))
   }
 
-  target_int <- as.integer(target_value[1])
+  state <- numeric_sync_state(session)
+  key <- paste0("input_", input_id)
 
-  session$onFlushed(function() {
-    updateNumericInput(session, input_id, value = target_int)
-  }, once = TRUE)
+  current_int <- suppressWarnings(as.integer(current_value[1]))
+  missing_current <- length(current_value) == 0 || is.na(current_int)
 
-  invisible(TRUE)
+  if (!exists(key, envir = state, inherits = FALSE)) {
+    assign(key, list(value = NULL, auto = TRUE), envir = state)
+  }
+
+  entry <- get(key, envir = state, inherits = FALSE)
+
+  if (missing_current) {
+    assign(key, list(value = target_int, auto = TRUE), envir = state)
+    session$onFlushed(function() {
+      updateNumericInput(session, input_id, value = target_int)
+    }, once = TRUE)
+    return(invisible(TRUE))
+  }
+
+  if (!identical(current_int, entry$value)) {
+    entry <- list(value = current_int, auto = FALSE)
+    assign(key, entry, envir = state)
+  }
+
+  if (isTRUE(entry$auto) && !identical(current_int, target_int)) {
+    assign(key, list(value = target_int, auto = TRUE), envir = state)
+    session$onFlushed(function() {
+      updateNumericInput(session, input_id, value = target_int)
+    }, once = TRUE)
+    return(invisible(TRUE))
+  }
+
+  invisible(FALSE)
 }


### PR DESCRIPTION
## Summary
- ensure grid row/column numeric inputs only auto-fill when they are unset or still using an automatic value
- remember the last auto-synced value per input so manual overrides are preserved while defaults can still respond to data changes

## Testing
- Rscript -e "source('R/module_visualize_layout.R')" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_690c6eb9fc20832b8e7be267243adb0c