### PR TITLE
Add barplot option with significance for one-way ANOVA

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -16,6 +16,11 @@ visualize_oneway_ui <- function(id) {
         choices = c("Mean ± SE" = "mean_se"),
         selected = "mean_se"
       ),
+      checkboxInput(
+        ns("show_barplot"),
+        label = "Show barplot with p-values",
+        value = FALSE
+      ),
       hr(),
       uiOutput(ns("layout_controls")),
       fluidRow(
@@ -50,7 +55,193 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       color_var_reactive = reactive(NULL),
       multi_group = FALSE
     )
-    
+
+    build_significance_annotations <- function(pairwise_df, stats_df, factor_var) {
+      if (is.null(pairwise_df) || nrow(pairwise_df) == 0) {
+        return(NULL)
+      }
+      factor_cols <- intersect(c("Factor", "factor", "term", "Term"), names(pairwise_df))
+      if (length(factor_cols) > 0) {
+        factor_values <- pairwise_df[[factor_cols[1]]]
+        if (is.factor(factor_values)) {
+          factor_values <- as.character(factor_values)
+        }
+        matched <- factor_values == factor_var
+        matched[is.na(matched)] <- FALSE
+        pairwise_df <- pairwise_df[matched, , drop = FALSE]
+      }
+
+      if (nrow(pairwise_df) == 0 || !"p.value" %in% names(pairwise_df)) {
+        return(NULL)
+      }
+
+      p_vals <- pairwise_df$p.value
+      if (is.factor(p_vals)) {
+        p_vals <- as.character(p_vals)
+      }
+      if (is.character(p_vals)) {
+        cleaned <- gsub("\\*", "", p_vals, fixed = FALSE)
+        cleaned <- trimws(cleaned)
+        cleaned <- sub("^<", "", cleaned)
+        p_vals <- suppressWarnings(as.numeric(cleaned))
+      } else {
+        p_vals <- suppressWarnings(as.numeric(p_vals))
+      }
+      valid <- !is.na(p_vals) & p_vals < 0.05
+      if (!any(valid)) {
+        return(NULL)
+      }
+
+      contrast_col <- intersect(c("contrast", "comparison", "Contrast", "Comparison"), names(pairwise_df))
+      if (length(contrast_col) == 0) {
+        return(NULL)
+      }
+
+      contrasts <- as.character(pairwise_df[[contrast_col[1]]])
+      parts <- strsplit(contrasts, "\\s*-\\s*")
+      group1 <- vapply(parts, function(x) if (length(x) >= 1) trimws(x[1]) else NA_character_, character(1))
+      group2 <- vapply(parts, function(x) if (length(x) >= 2) trimws(x[length(x)]) else NA_character_, character(1))
+
+      group1 <- group1[valid]
+      group2 <- group2[valid]
+      p_vals <- p_vals[valid]
+
+      valid_pairs <- !is.na(group1) & !is.na(group2)
+      if (!any(valid_pairs)) {
+        return(NULL)
+      }
+
+      group1 <- group1[valid_pairs]
+      group2 <- group2[valid_pairs]
+      p_vals <- p_vals[valid_pairs]
+
+      level_values <- if (is.factor(stats_df[[factor_var]])) {
+        levels(stats_df[[factor_var]])
+      } else {
+        unique(as.character(stats_df[[factor_var]]))
+      }
+
+      positions1 <- match(group1, level_values)
+      positions2 <- match(group2, level_values)
+
+      keep <- !is.na(positions1) & !is.na(positions2)
+      if (!any(keep)) {
+        return(NULL)
+      }
+
+      positions1 <- positions1[keep]
+      positions2 <- positions2[keep]
+      p_vals <- p_vals[keep]
+
+      annotations <- ifelse(p_vals < 0.001, "***",
+                            ifelse(p_vals < 0.01, "**", "*"))
+
+      se_vals <- if ("se" %in% names(stats_df)) stats_df$se else rep(0, nrow(stats_df))
+      upper_vals <- stats_df$mean + se_vals
+      upper_vals[!is.finite(upper_vals)] <- stats_df$mean[!is.finite(upper_vals)]
+
+      base_y <- suppressWarnings(max(upper_vals, na.rm = TRUE))
+      if (!is.finite(base_y)) {
+        base_y <- suppressWarnings(max(stats_df$mean, na.rm = TRUE))
+      }
+      if (!is.finite(base_y)) {
+        base_y <- 0
+      }
+
+      step <- abs(base_y) * 0.1
+      if (!is.finite(step) || step == 0) {
+        step <- 0.1
+      }
+
+      order_idx <- order(p_vals)
+      positions1 <- positions1[order_idx]
+      positions2 <- positions2[order_idx]
+      annotations <- annotations[order_idx]
+      p_vals <- p_vals[order_idx]
+
+      y_positions <- base_y + step * seq_along(p_vals)
+
+      signif_df <- data.frame(
+        xmin = positions1,
+        xmax = positions2,
+        annotation = annotations,
+        y_position = y_positions,
+        stringsAsFactors = FALSE
+      )
+
+      list(
+        data = signif_df,
+        max_y = suppressWarnings(max(y_positions, na.rm = TRUE))
+      )
+    }
+
+    build_bar_plot_for_stats <- function(stats_df, title_text, factor_var, fill_color, pairwise_df) {
+      if (is.null(stats_df) || nrow(stats_df) == 0) {
+        return(NULL)
+      }
+
+      stats_df[[factor_var]] <- as.factor(stats_df[[factor_var]])
+      se_vals <- if ("se" %in% names(stats_df)) stats_df$se else rep(0, nrow(stats_df))
+      stats_df$ymin <- stats_df$mean - se_vals
+      stats_df$ymax <- stats_df$mean + se_vals
+
+      annotation_info <- build_significance_annotations(pairwise_df, stats_df, factor_var)
+
+      y_lower <- suppressWarnings(min(stats_df$ymin, na.rm = TRUE))
+      y_upper <- suppressWarnings(max(stats_df$ymax, na.rm = TRUE))
+
+      if (!is.null(annotation_info) && !is.null(annotation_info$max_y) && is.finite(annotation_info$max_y)) {
+        if (!is.finite(y_upper)) {
+          y_upper <- annotation_info$max_y
+        } else {
+          y_upper <- max(y_upper, annotation_info$max_y)
+        }
+      }
+
+      y_limits <- NULL
+      if (is.finite(y_lower) && is.finite(y_upper)) {
+        span <- y_upper - y_lower
+        if (!is.finite(span) || span == 0) {
+          span <- ifelse(abs(y_upper) > 0, abs(y_upper), 1)
+        }
+        padding <- span * 0.1
+        if (!is.finite(padding) || padding == 0) {
+          padding <- 0.1
+        }
+        y_limits <- c(y_lower - padding * 0.25, y_upper + padding)
+      }
+
+      p <- ggplot(stats_df, aes(x = !!rlang::sym(factor_var), y = mean)) +
+        geom_col(fill = fill_color, width = 0.65) +
+        geom_errorbar(aes(ymin = ymin, ymax = ymax), width = 0.15) +
+        theme_minimal(base_size = 14) +
+        labs(x = factor_var, y = "Mean ± SE") +
+        theme(
+          panel.grid.minor = element_blank(),
+          panel.grid.major.x = element_blank()
+        )
+
+      if (!is.null(annotation_info) && !is.null(annotation_info$data) &&
+          nrow(annotation_info$data) > 0 &&
+          requireNamespace("ggsignif", quietly = TRUE)) {
+        p <- p + ggsignif::geom_signif(
+          data = annotation_info$data,
+          aes(xmin = xmin, xmax = xmax, annotations = annotation, y_position = y_position),
+          inherit.aes = FALSE,
+          manual = TRUE,
+          tip_length = 0.01,
+          textsize = 4
+        )
+      }
+
+      if (!is.null(y_limits) && all(is.finite(y_limits))) {
+        p <- p + scale_y_continuous(limits = y_limits)
+      }
+
+      p + ggtitle(title_text) +
+        theme(plot.title = element_text(size = 12, face = "bold"))
+    }
+
     # ---- Build plot info ----
     plot_info <- reactive({
       info <- model_info()
@@ -91,6 +282,125 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
         w = input$plot_width * s$strata$cols * s$responses$ncol,
         h = input$plot_height * s$strata$rows * s$responses$nrow
       )
+    })
+
+    pairwise_results <- reactive({
+      info <- model_info()
+      req(info)
+
+      posthoc <- info$posthoc
+      if (is.null(posthoc) || length(posthoc) == 0) {
+        return(NULL)
+      }
+
+      posthoc
+    })
+
+    bar_plot_obj <- reactive({
+      if (!isTRUE(input$show_barplot)) {
+        return(NULL)
+      }
+
+      info <- plot_info()
+      if (is.null(info) || !is.null(info$warning)) {
+        return(NULL)
+      }
+
+      stats <- info$summary_stats
+      if (is.null(stats) || length(stats) == 0) {
+        return(NULL)
+      }
+
+      meta <- model_info()
+      req(meta)
+
+      factor1 <- meta$factors$factor1
+      if (is.null(factor1)) {
+        return(NULL)
+      }
+
+      responses <- meta$responses
+      has_strata <- isTRUE(info$has_strata)
+
+      colors <- custom_colors()
+      fill_color <- if (!is.null(colors) && length(colors) > 0) {
+        unname(colors)[1]
+      } else {
+        resolve_single_color()
+      }
+
+      pairwise <- pairwise_results()
+      response_plots <- list()
+
+      if (has_strata) {
+        for (resp in responses) {
+          stats_entry <- stats[[resp]]
+          if (is.null(stats_entry) || is.null(stats_entry$strata)) next
+
+          stratum_plots <- list()
+          stratum_names <- names(stats_entry$strata)
+
+          for (stratum_name in stratum_names) {
+            stratum_df <- stats_entry$strata[[stratum_name]]
+            if (is.null(stratum_df) || nrow(stratum_df) == 0) next
+
+            pairwise_df <- NULL
+            if (!is.null(pairwise) && !is.null(pairwise[[resp]]) &&
+                !is.null(pairwise[[resp]][[stratum_name]])) {
+              pairwise_df <- pairwise[[resp]][[stratum_name]]
+            }
+
+            plot <- build_bar_plot_for_stats(stratum_df, stratum_name, factor1, fill_color, pairwise_df)
+            if (!is.null(plot)) {
+              stratum_plots[[stratum_name]] <- plot
+            }
+          }
+
+          if (length(stratum_plots) == 0) next
+
+          combined <- patchwork::wrap_plots(
+            plotlist = stratum_plots,
+            nrow = info$layout$strata$rows,
+            ncol = info$layout$strata$cols
+          )
+
+          title_plot <- ggplot() +
+            theme_void() +
+            ggtitle(resp) +
+            theme(
+              plot.title = element_text(size = 16, face = "bold", hjust = 0.5),
+              plot.margin = margin(t = 0, r = 0, b = 6, l = 0)
+            )
+
+          response_plots[[resp]] <- title_plot / combined + patchwork::plot_layout(heights = c(0.08, 1))
+        }
+      } else {
+        for (resp in responses) {
+          stats_entry <- stats[[resp]]
+          if (is.null(stats_entry) || is.null(stats_entry$data) || nrow(stats_entry$data) == 0) next
+
+          pairwise_df <- if (!is.null(pairwise)) pairwise[[resp]] else NULL
+          plot <- build_bar_plot_for_stats(stats_entry$data, resp, factor1, fill_color, pairwise_df)
+          if (!is.null(plot)) {
+            response_plots[[resp]] <- plot
+          }
+        }
+      }
+
+      if (length(response_plots) == 0) {
+        return(NULL)
+      }
+
+      if (length(response_plots) == 1) {
+        return(response_plots[[1]])
+      }
+
+      patchwork::wrap_plots(
+        plotlist = response_plots,
+        nrow = info$layout$responses$nrow,
+        ncol = info$layout$responses$ncol
+      ) &
+        patchwork::plot_layout(guides = "collect")
     })
 
     observeEvent(plot_info(), {
@@ -139,23 +449,31 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
     output$plot <- renderPlot({
       info <- model_info()
       req(info, input$plot_type)
-      if (input$plot_type == "mean_se") {
-        plot <- plot_obj()
-        if (is.null(plot)) return(NULL)
-        plot
+
+      plot <- if (isTRUE(input$show_barplot) && input$plot_type == "mean_se") {
+        bar_plot_obj()
+      } else {
+        plot_obj()
       }
+
+      if (is.null(plot)) return(NULL)
+      plot
     },
     width = function() plot_size()$w,
     height = function() plot_size()$h,
     res = 96)
-    
+
     # ---- Download handler ----
     output$download_plot <- downloadHandler(
       filename = function() paste0("anova_plot_", Sys.Date(), ".png"),
       content = function(file) {
         info <- plot_info()
         req(is.null(info$warning))
-        plot <- plot_obj()
+        plot <- if (isTRUE(input$show_barplot) && input$plot_type == "mean_se") {
+          bar_plot_obj()
+        } else {
+          plot_obj()
+        }
         req(plot)
         ggsave(
           filename = file,

--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -711,6 +711,7 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
   }
   
   response_plots <- list()
+  summary_stats <- list()
 
   layout_input <- list(
     strata_rows = suppressWarnings(as.numeric(layout_values$strata_rows)),
@@ -849,20 +850,30 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
         )
       
       response_plots[[resp]] <- title_plot / combined + plot_layout(heights = c(0.08, 1))
-      
+      summary_stats[[resp]] <- list(
+        data = NULL,
+        strata = stratum_plots,
+        y_limits = y_limits
+      )
+
     } else {
       stats_df <- compute_stats(data, resp)
       if (nrow(stats_df) == 0) {
         next
       }
-      
+
       y_values <- c(stats_df$mean - stats_df$se, stats_df$mean + stats_df$se)
       y_limits <- range(y_values, na.rm = TRUE)
       if (!all(is.finite(y_limits))) {
         y_limits <- NULL
       }
-      
+
       response_plots[[resp]] <- build_plot(stats_df, resp, y_limits)
+      summary_stats[[resp]] <- list(
+        data = stats_df,
+        strata = NULL,
+        y_limits = y_limits
+      )
     }
   }
 
@@ -933,7 +944,8 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
     defaults = list(
       strata = strata_defaults,
       responses = response_defaults
-    )
+    ),
+    summary_stats = summary_stats
   )
 }
 


### PR DESCRIPTION
## Summary
- add a sidebar option to toggle between the existing mean ± SE line plot and a new barplot for one-way ANOVA visuals
- build barplots from the existing summary statistics, reusing layout defaults and integrating pairwise Tukey comparisons to annotate significant contrasts
- ensure downloads and rendering honor the selected visualization while keeping existing styling intact
- reuse the existing ANOVA post-hoc contrasts for barplot annotations instead of recomputing them in the visualization module

## Testing
- `Rscript -e "source('R/anova_oneway_visualize.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_690c79650cb8832babe9e078e548186a