### PR TITLE
Fix ANOVA barplot significance annotations with multiple responses

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -246,6 +246,13 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
           nrow(annotation_info$data) > 0) {
         p <- p + ggsignif::geom_signif(
           data = annotation_info$data,
+          mapping = aes(
+            xmin = .data$xmin,
+            xmax = .data$xmax,
+            annotations = .data$annotation,
+            y_position = .data$y_position
+          ),
+          inherit.aes = FALSE,
           tip_length = 0.01,
           textsize = 4
         )


### PR DESCRIPTION
## Summary
- prevent the ggsignif layer from inheriting the bar plot aesthetics
- explicitly map the annotation columns so p-value bars render correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690ca80fecb0832bb8cfa88c720f71ed