### PR TITLE
Add color customization controls across descriptive and multivariate plots

### DIFF
--- a/R/module_colors_helpers.R
+++ b/R/module_colors_helpers.R
@@ -31,7 +31,13 @@ render_color_inputs <- function(ns, data, color_var) {
   )
 }
 
-resolve_single_color <- function() {
+resolve_single_color <- function(custom = NULL) {
+  if (!is.null(custom) && length(custom) > 0) {
+    candidate <- unname(custom[[1]])
+    if (!is.null(candidate) && nzchar(candidate)) {
+      return(candidate)
+    }
+  }
   basic_color_palette[1]
 }
 


### PR DESCRIPTION
## Summary
- add the color customization widget to all descriptive statistic plot types so grouped and single plots can be recolored
- extend the pairwise scatterplot matrix and PCA biplot to support the same color customization, propagating choices into the plots
- update shared color helpers to accept overrides for both grouped palettes and single-color cases

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_690cad1f17c8832bae80e904f7765153