### PR TITLE
Fix grid layout persistence after stratified analyses

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -834,10 +834,12 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
         build_plot(stratum_plots[[stratum_name]], stratum_name, y_limits)
       })
 
+      current_layout <- adjust_grid_layout(length(stratum_plots), strata_layout)
+
       combined <- patchwork::wrap_plots(
         plotlist = strata_plot_list,
-        nrow = strata_layout$nrow,
-        ncol = strata_layout$ncol
+        nrow = current_layout$nrow,
+        ncol = current_layout$ncol
       )
 
       title_plot <- ggplot() +
@@ -874,6 +876,10 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
     strata_panel_count <- n_expected_strata
   }
 
+  if (has_strata) {
+    strata_layout <- adjust_grid_layout(max(1L, strata_panel_count), strata_layout)
+  }
+
   response_defaults <- compute_default_grid(length(response_plots))
   response_layout <- basic_grid_layout(
     rows = layout_input$resp_rows,
@@ -881,6 +887,8 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
     default_rows = response_defaults$rows,
     default_cols = response_defaults$cols
   )
+
+  response_layout <- adjust_grid_layout(length(response_plots), response_layout)
 
   strata_validation <- if (has_strata) {
     validate_grid(max(1L, strata_panel_count), strata_layout$nrow, strata_layout$ncol)

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -344,6 +344,8 @@ build_descriptive_categorical_plot <- function(df,
     default_cols = defaults$cols
   )
 
+  layout <- adjust_grid_layout(n_panels, layout)
+
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
 
   combined <- NULL

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -279,6 +279,8 @@ build_descriptive_numeric_boxplot <- function(df,
     default_cols = defaults$cols
   )
 
+  layout <- adjust_grid_layout(n_panels, layout)
+
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
 
   combined <- NULL

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -287,6 +287,8 @@ build_descriptive_numeric_histogram <- function(df,
     default_cols = defaults$cols
   )
 
+  layout <- adjust_grid_layout(n_panels, layout)
+
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
 
   combined <- NULL

--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -81,6 +81,54 @@ basic_grid_layout <- function(rows = NULL,
   )
 }
 
+adjust_grid_layout <- function(n_items, layout) {
+  if (is.null(layout) || length(layout) == 0) {
+    return(list(nrow = 1L, ncol = 1L))
+  }
+
+  if (is.null(n_items) || length(n_items) == 0 || is.na(n_items)) {
+    n_items <- 1L
+  }
+  n_items <- max(1L, as.integer(n_items))
+
+  rows <- layout$nrow
+  cols <- layout$ncol
+
+  if (is.null(rows) || length(rows) == 0 || is.na(rows)) {
+    rows <- 1L
+  }
+  if (is.null(cols) || length(cols) == 0 || is.na(cols)) {
+    cols <- 1L
+  }
+
+  rows <- max(1L, as.integer(rows))
+  cols <- max(1L, as.integer(cols))
+
+  if (rows * cols <= n_items) {
+    return(list(nrow = rows, ncol = cols))
+  }
+
+  repeat {
+    adjusted <- FALSE
+
+    if (rows > 1L && (rows - 1L) * cols >= n_items) {
+      rows <- rows - 1L
+      adjusted <- TRUE
+    }
+
+    if (cols > 1L && rows * (cols - 1L) >= n_items) {
+      cols <- cols - 1L
+      adjusted <- TRUE
+    }
+
+    if (!adjusted) {
+      break
+    }
+  }
+
+  list(nrow = rows, ncol = cols)
+}
+
 numeric_sync_state <- function(session) {
   state <- session$userData$ta_numeric_sync_state
   if (is.null(state) || !is.environment(state)) {

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -205,6 +205,8 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
           default_cols = defaults$cols
         )
 
+        layout <- adjust_grid_layout(panel_count, layout)
+
         validation <- validate_grid(panel_count, layout$nrow, layout$ncol)
 
         combined <- NULL


### PR DESCRIPTION
## Summary
- add an adjust_grid_layout helper that automatically clamps grid dimensions to the number of rendered panels
- apply the helper across descriptive, correlation, and ANOVA visualizations so layouts reset when returning from stratified analyses

## Testing
- Not run (Rscript unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690cc6a66358832bb19b316665922e05