### PR TITLE
Align ANOVA plot info outputs

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -925,18 +925,14 @@ build_anova_plot_info <- function(data, info, layout_values, line_colors = NULL)
     plot = final_plot,
     layout = list(
       strata = list(
-        rows = strata_layout$nrow,
-        cols = strata_layout$ncol,
-        panels = max(1L, strata_panel_count)
+        rows = if (has_strata) strata_layout$nrow else 1L,
+        cols = if (has_strata) strata_layout$ncol else 1L
       ),
       responses = list(
-        nrow = response_layout$nrow,
-        ncol = response_layout$ncol,
-        panels = length(response_plots)
+        rows = response_layout$nrow,
+        cols = response_layout$ncol
       )
     ),
-    has_strata = has_strata,
-    n_responses = length(response_plots),
     warning = warning_text,
     defaults = list(
       strata = strata_defaults,

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -98,9 +98,13 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
       info <- plot_info()
       req(info)
       s <- info$layout
+      strata_rows <- if (!is.null(s$strata$rows)) s$strata$rows else 1
+      strata_cols <- if (!is.null(s$strata$cols)) s$strata$cols else 1
+      resp_rows <- if (!is.null(s$responses$rows)) s$responses$rows else 1
+      resp_cols <- if (!is.null(s$responses$cols)) s$responses$cols else 1
       list(
-        w = input$plot_width  * s$strata$cols   * s$responses$ncol,
-        h = input$plot_height * s$strata$rows   * s$responses$nrow
+        w = input$plot_width  * strata_cols * resp_cols,
+        h = input$plot_height * strata_rows * resp_rows
       )
     })
 
@@ -139,6 +143,9 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
 
     output$plot_warning <- renderUI({
       info <- plot_info()
+      if (is.null(info)) {
+        return(NULL)
+      }
       if (!is.null(info$warning)) {
         div(class = "alert alert-warning", HTML(info$warning))
       } else {
@@ -165,6 +172,7 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
       filename = function() paste0(input$plot_type, "_twoway_anova_plot_", Sys.Date(), ".png"),
       content = function(file) {
         info <- plot_info()
+        req(info)
         req(is.null(info$warning))
         plot <- plot_obj()
         req(plot)


### PR DESCRIPTION
## Summary
- return unified plot info metadata from the one-way ANOVA barplot helper so it matches the shared builder
- trim `build_anova_plot_info` to the minimal plot, layout, defaults, and warning fields now shared across both paths
- update one-way and two-way visualization modules to consume the unified structure for sizing, warnings, and downloads

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f00971a34832b8df377f28882ad05)