### PR TITLE
Refactor two-way ANOVA visualization module

### DIFF
--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -13,13 +13,15 @@ visualize_twoway_ui <- function(id) {
       selectInput(
         ns("plot_type"),
         label = "Select visualization type:",
-        choices = c("Mean ± SE" = "mean_se"),
-        selected = "mean_se"
+        choices = c(
+          "Lineplots (mean ± SE)" = "lineplot_mean_se"
+        ),
+        selected = "lineplot_mean_se"
       ),
       hr(),
       uiOutput(ns("layout_controls")),
       fluidRow(
-        column(6, numericInput(ns("plot_width"), "Subplot width (px)",  value = 400, min = 200, max = 1200, step = 50)),
+        column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 1200, step = 50)),
         column(6, numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50))
       ),
       add_color_customization_ui(ns, multi_group = TRUE),
@@ -30,24 +32,22 @@ visualize_twoway_ui <- function(id) {
       width = 8,
       h4("Plots"),
       uiOutput(ns("plot_warning")),
-      plotOutput(ns("plot"), height = "auto")   # ✅ same as one-way
+      plotOutput(ns("plot"), height = "auto")
     )
   )
 }
 
 
-visualize_twoway_server <- function(id, filtered_data, model_fit) {
+visualize_twoway_server <- function(id, filtered_data, model_info) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     df <- reactive(filtered_data())
-    
-    model_info <- reactive(model_fit())
-    
-    # ---- color customization ----
+
+    # ---- Plug in color customization module (multi-color mode) ----
     color_var_reactive <- reactive({
       info <- model_info()
-      if (is.null(info)) return(NULL)
-      info$factors$factor2   # color lines by factor2
+      if (is.null(info) || is.null(info$factors)) return(NULL)
+      info$factors$factor2
     })
 
     custom_colors <- add_color_customization_server(
@@ -61,21 +61,23 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
 
     plot_info <- reactive({
       info <- model_info()
-      req(info)
+      req(info, input$plot_type)
       validate(
-        need(info$type == "twoway_anova", "Loaded analysis is not a two-way ANOVA result.")
+        need(info$type == "twoway_anova", "No two-way ANOVA results available for plotting.")
       )
+
       data <- df()
-      line_colors <- custom_colors()
-      if (is.null(line_colors) || length(line_colors) == 0) {
-        line_colors <- NULL
-      }
       layout_inputs <- list(
         strata_rows = input$strata_rows,
         strata_cols = input$strata_cols,
         resp_rows = input$resp_rows,
         resp_cols = input$resp_cols
       )
+
+      line_colors <- custom_colors()
+      if (is.null(line_colors) || length(line_colors) == 0) {
+        line_colors <- NULL
+      }
 
       build_anova_plot_info(
         data,
@@ -84,16 +86,16 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
         line_colors = line_colors
       )
     })
-    
+
     plot_obj <- reactive({
       info <- plot_info()
-      if (is.null(info)) return(NULL)
+      req(info)
       if (!is.null(info$warning) || is.null(info$plot)) {
         return(NULL)
       }
       info$plot
     })
-    
+
     plot_size <- reactive({
       info <- plot_info()
       req(info)
@@ -103,7 +105,7 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
       resp_rows <- if (!is.null(s$responses$rows)) s$responses$rows else 1
       resp_cols <- if (!is.null(s$responses$cols)) s$responses$cols else 1
       list(
-        w = input$plot_width  * strata_cols * resp_cols,
+        w = input$plot_width * strata_cols * resp_cols,
         h = input$plot_height * strata_rows * resp_rows
       )
     })
@@ -134,7 +136,7 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
         }
       }
     }, ignoreNULL = FALSE)
-    
+
     output$layout_controls <- renderUI({
       info <- model_info()
       req(info)
@@ -152,38 +154,32 @@ visualize_twoway_server <- function(id, filtered_data, model_fit) {
         NULL
       }
     })
-    
-    # ✅ simpler, consistent naming and structure
-    output$plot <- renderPlot({
-      info <- model_info()
-      req(info, input$plot_type)
 
-      if (input$plot_type == "mean_se") {
-        plot <- plot_obj()
-        if (is.null(plot)) return(NULL)
-        plot
-      }
+    output$plot <- renderPlot({
+      req(input$plot_type == "lineplot_mean_se")
+      plot <- plot_obj()
+      if (is.null(plot)) return(NULL)
+      plot
     },
     width = function() plot_size()$w,
     height = function() plot_size()$h,
     res = 96)
-    
+
     output$download_plot <- downloadHandler(
-      filename = function() paste0(input$plot_type, "_twoway_anova_plot_", Sys.Date(), ".png"),
+      filename = function() paste0("anova_plot_", Sys.Date(), ".png"),
       content = function(file) {
         info <- plot_info()
         req(info)
         req(is.null(info$warning))
         plot <- plot_obj()
         req(plot)
-        s <- plot_size()
         ggsave(
           filename = file,
           plot = plot,
           device = "png",
           dpi = 300,
-          width  = s$w / 96,
-          height = s$h / 96,
+          width = plot_size()$w / 96,
+          height = plot_size()$h / 96,
           units = "in",
           limitsize = FALSE
         )


### PR DESCRIPTION
## Summary
- align the two-way ANOVA visualization UI controls with the one-way module for consistent layout and sizing options
- refactor the server logic to share the same plot-info, warning, and sizing workflow used by the one-way module
- keep lineplot rendering while wiring in multi-group color customization and standardized download handling

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0e199c94832b8f0655a2f3ee7939)