### PR TITLE
Cache two-way ANOVA visualizations

### DIFF
--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -81,89 +81,175 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       last_plot_type(input$plot_type)
     }, ignoreNULL = FALSE)
 
-    plot_info <- reactive({
-      info <- model_info()
-      plot_type <- last_plot_type()
-      req(info, plot_type)
-      validate(
-        need(info$type == "twoway_anova", "No two-way ANOVA results available for plotting.")
-      )
+    cached_results <- reactiveValues(plots = list())
 
-      data <- df()
-      layout_inputs <- list(
-        strata_rows = input$strata_rows,
-        strata_cols = input$strata_cols,
-        resp_rows = input$resp_rows,
-        resp_cols = input$resp_cols
+    compute_empty_result <- function(message = NULL) {
+      list(
+        plot = NULL,
+        warning = message,
+        layout = NULL,
+        defaults = NULL
       )
+    }
 
-      line_colors <- custom_colors()
+    compute_all_plots <- function(data, info, layout_inputs, colors) {
+      if (is.null(info)) {
+        return(list())
+      }
+
+      if (!identical(info$type, "twoway_anova")) {
+        msg <- "No two-way ANOVA results available for plotting."
+        return(list(
+          lineplot_mean_se = compute_empty_result(msg),
+          barplot_mean_se = compute_empty_result(msg)
+        ))
+      }
+
+      if (is.null(data) || (!is.null(data) && nrow(data) == 0)) {
+        msg <- "No data available for plotting."
+        return(list(
+          lineplot_mean_se = compute_empty_result(msg),
+          barplot_mean_se = compute_empty_result(msg)
+        ))
+      }
+
+      safe_plot <- function(expr) {
+        tryCatch({
+          result <- expr
+          if (is.null(result)) {
+            compute_empty_result("Unable to generate plot.")
+          } else {
+            result
+          }
+        }, error = function(e) {
+          compute_empty_result(e$message)
+        })
+      }
+
+      line_colors <- colors
       if (is.null(line_colors) || length(line_colors) == 0) {
         line_colors <- NULL
       }
 
-      if (identical(plot_type, "barplot_mean_se")) {
-        posthoc_all <- compile_anova_results(info)$posthoc
-        plot_anova_barplot_meanse(
-          data,
-          info,
-          layout_values = layout_inputs,
-          line_colors = line_colors,
-          posthoc_all = posthoc_all
-        )
-      } else {
+      results <- list()
+
+      results$lineplot_mean_se <- safe_plot(
         plot_anova_lineplot_meanse(
           data,
           info,
           layout_inputs,
           line_colors = line_colors
         )
+      )
+
+      posthoc_data <- tryCatch(
+        compile_anova_results(info)$posthoc,
+        error = function(e) NULL
+      )
+
+      results$barplot_mean_se <- safe_plot(
+        plot_anova_barplot_meanse(
+          data,
+          info,
+          layout_values = layout_inputs,
+          line_colors = line_colors,
+          posthoc_all = posthoc_data
+        )
+      )
+
+      results
+    }
+
+    observeEvent(
+      list(
+        model_info(),
+        df(),
+        input$strata_rows,
+        input$strata_cols,
+        input$resp_rows,
+        input$resp_cols,
+        custom_colors()
+      ),
+      {
+        info <- model_info()
+        data <- df()
+        layout_inputs <- list(
+          strata_rows = input$strata_rows,
+          strata_cols = input$strata_cols,
+          resp_rows = input$resp_rows,
+          resp_cols = input$resp_cols
+        )
+
+        cached_results$plots <- compute_all_plots(data, info, layout_inputs, custom_colors())
+      },
+      ignoreNULL = FALSE
+    )
+
+    results <- reactive(cached_results$plots)
+
+    current_result <- reactive({
+      res <- results()
+      if (length(res) == 0) {
+        return(NULL)
       }
+      res[[input$plot_type]]
     })
 
     plot_obj <- reactive({
-      info <- plot_info()
-      req(info)
-      if (!is.null(info$warning) || is.null(info$plot)) {
+      info <- current_result()
+      if (is.null(info) || !is.null(info$warning) || is.null(info$plot)) {
         return(NULL)
       }
       info$plot
     })
 
     plot_size <- reactive({
-      info <- plot_info()
-      req(info)
-      s <- info$layout
-      strata_rows <- if (!is.null(s$strata$rows)) s$strata$rows else 1
-      strata_cols <- if (!is.null(s$strata$cols)) s$strata$cols else 1
-      resp_rows <- if (!is.null(s$responses$rows)) s$responses$rows else 1
-      resp_cols <- if (!is.null(s$responses$cols)) s$responses$cols else 1
+      res <- current_result()
+      layout <- if (!is.null(res)) res$layout else NULL
+      strata_layout <- if (!is.null(layout) && !is.null(layout$strata)) layout$strata else list()
+      response_layout <- if (!is.null(layout) && !is.null(layout$responses)) layout$responses else list()
+      strata_rows <- if (!is.null(strata_layout$rows)) strata_layout$rows else 1
+      strata_cols <- if (!is.null(strata_layout$cols)) strata_layout$cols else 1
+      resp_rows <- if (!is.null(response_layout$rows)) response_layout$rows else 1
+      resp_cols <- if (!is.null(response_layout$cols)) response_layout$cols else 1
       list(
         w = input$plot_width * strata_cols * resp_cols,
         h = input$plot_height * strata_rows * resp_rows
       )
     })
 
-    observeEvent(plot_info(), {
-      info <- plot_info()
-      if (is.null(info) || is.null(info$defaults) || is.null(info$layout)) {
+    observeEvent(results(), {
+      res_list <- results()
+      if (length(res_list) == 0) {
         return()
       }
 
-      if (!is.null(info$defaults$strata)) {
-        defaults <- info$defaults$strata
-        rows <- defaults$rows
-        cols <- defaults$cols
+      first_valid <- NULL
+      for (item in res_list) {
+        if (!is.null(item$defaults) && !is.null(item$layout)) {
+          first_valid <- item
+          break
+        }
+      }
+
+      if (is.null(first_valid)) {
+        return()
+      }
+
+      defaults <- first_valid$defaults
+
+      if (!is.null(defaults$strata)) {
+        rows <- defaults$strata$rows
+        cols <- defaults$strata$cols
         if (!is.null(rows) && !is.null(cols)) {
           sync_numeric_input(session, "strata_rows", input$strata_rows, rows)
           sync_numeric_input(session, "strata_cols", input$strata_cols, cols)
         }
       }
 
-      if (!is.null(info$defaults$responses)) {
-        defaults <- info$defaults$responses
-        rows <- defaults$rows
-        cols <- defaults$cols
+      if (!is.null(defaults$responses)) {
+        rows <- defaults$responses$rows
+        cols <- defaults$responses$cols
         if (!is.null(rows) && !is.null(cols)) {
           sync_numeric_input(session, "resp_rows", input$resp_rows, rows)
           sync_numeric_input(session, "resp_cols", input$resp_cols, cols)
@@ -178,7 +264,7 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     })
 
     output$plot_warning <- renderUI({
-      info <- plot_info()
+      info <- current_result()
       if (is.null(info)) {
         return(NULL)
       }
@@ -201,18 +287,19 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     output$download_plot <- downloadHandler(
       filename = function() paste0("anova_plot_", Sys.Date(), ".png"),
       content = function(file) {
-        info <- plot_info()
+        info <- current_result()
         req(info)
         req(is.null(info$warning))
         plot <- plot_obj()
         req(plot)
+        size <- plot_size()
         ggsave(
           filename = file,
           plot = plot,
           device = "png",
           dpi = 300,
-          width = plot_size()$w / 96,
-          height = plot_size()$h / 96,
+          width = size$w / 96,
+          height = size$h / 96,
           units = "in",
           limitsize = FALSE
         )


### PR DESCRIPTION
## Summary
- cache two-way ANOVA plot computations so visualizations reuse prior results
- align layout synchronization and warning handling with the one-way ANOVA module

## Testing
- Rscript -e 'testthat::test_dir("tests")' *(fails: command not found: Rscript)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7981ab10832bab72dfbb59437075)