### PR TITLE
Improve empty state styling in visualization tab

### DIFF
--- a/R/module_visualize.R
+++ b/R/module_visualize.R
@@ -53,7 +53,21 @@ visualize_server <- function(id, filtered_data, model_fit) {
         "pairs"          = visualize_ggpairs_ui(ns("ggpairs")),
         "pca"            = visualize_pca_ui(ns("pca"), filtered_data()),
         "descriptive"    = visualize_descriptive_ui(ns("descriptive")),
-        div("Visualization not yet implemented for this analysis type.")
+        div(
+          class = "empty-state card bg-light border-0 shadow-sm text-center my-5",
+          div(
+            class = "card-body py-5 px-4",
+            div(
+              class = "empty-state-icon text-primary mb-3",
+              HTML("&#128065;")
+            ),
+            h4(class = "mb-2", "Visualization coming soon"),
+            p(
+              class = "text-muted mb-0",
+              "We're still crafting charts for this analysis type. In the meantime, explore the other visualizations available above!"
+            )
+          )
+        )
       )
     })
     

--- a/app.R
+++ b/app.R
@@ -46,6 +46,9 @@ ui <- navbarPage(
       .section { margin-top: 18px; }
       .card { border-radius: 16px; box-shadow: 0 4px 10px rgba(0,0,0,0.05); }
       .nav-tabs > li > a { font-weight: 500; }
+      .empty-state { max-width: 420px; margin-left: auto; margin-right: auto; }
+      .empty-state-icon { font-size: 3rem; line-height: 1; }
+      .empty-state h4 { font-weight: 600; }
     "))
   ),
   


### PR DESCRIPTION
## Summary
- replace the plain visualization placeholder with a themed empty state card
- add supporting CSS so the empty state matches the rest of the app styling

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7e1c4684832bbf17ed00ae4006e8)