### PR TITLE
Handle errors when converting wide uploads

### DIFF
--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -128,20 +128,23 @@ upload_server <- function(id) {
       
       if (input$data_source == "wide") {
         # ⚙️ Wide format conversion with error handling
-        data <- tryCatch(
-          convert_wide_to_long(
-            path,
-            sheet = input$sheet,
-            replicate_col = "Replicate"
-          ),
-          error = function(e) {
-            output$validation_msg <- renderText(
-              paste("❌ Error converting wide format:", conditionMessage(e))
-            )
-            NULL
-          }
+        safe_result <- safe_convert_wide_to_long(
+          path,
+          sheet = input$sheet,
+          replicate_col = "Replicate"
         )
-        if (is.null(data)) return()
+
+        if (!is.null(safe_result$error)) {
+          output$validation_msg <- renderText(
+            paste(
+              "❌ Error converting wide format:",
+              conditionMessage(safe_result$error)
+            )
+          )
+          return()
+        }
+
+        data <- safe_result$result
         output$validation_msg <- renderText("✅ Wide format reshaped successfully.")
       } else {
         # 🧾 Simple long format load

--- a/R/module_upload_helpers.R
+++ b/R/module_upload_helpers.R
@@ -58,3 +58,5 @@ convert_wide_to_long <- function(path, sheet = 1, replicate_col = "Replicate") {
   
   as_tibble(data_long)
 }
+
+safe_convert_wide_to_long <- purrr::safely(convert_wide_to_long)


### PR DESCRIPTION
## Summary
- add a purrr::safely wrapper for the wide-to-long converter
- update the upload server logic to use the safe wrapper and surface conversion errors in the UI

## Testing
- `Rscript -e "testthat::test_dir('tests')"` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f84ffb7c8832ba15d6bf0eaf9f7ae)