### PR TITLE
Ensure numeric selectors repopulate when modules reopen

### DIFF
--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -33,11 +33,27 @@ ggpairs_server <- function(id, data_reactive) {
     strat_info <- stratification_server("strat", df)
 
     # ---- Update variable selector ----
-    observe({
-      req(df())
-      num_vars <- names(df())[sapply(df(), is.numeric)]
-      updateSelectInput(session, "vars", choices = num_vars, selected = num_vars)
-    })
+    repopulate_numeric_selector <- function() {
+      data <- isolate(df())
+      if (is.null(data)) return()
+
+      num_vars <- names(data)[vapply(data, is.numeric, logical(1))]
+      previous <- isolate(input$vars)
+      selected <- intersect(previous %||% character(), num_vars)
+      if (length(selected) == 0) {
+        selected <- num_vars
+      }
+
+      updateSelectInput(session, "vars", choices = num_vars, selected = selected)
+    }
+
+    observeEvent(df(), {
+      repopulate_numeric_selector()
+    }, ignoreNULL = FALSE)
+
+    session$onFlushed(function() {
+      repopulate_numeric_selector()
+    }, once = FALSE)
 
     build_ggpairs_object <- function(data) {
       GGally::ggpairs(

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -35,10 +35,27 @@ pca_server <- function(id, filtered_data) {
     df <- reactive(filtered_data())
 
     # Dynamically populate numeric variable list
-    observe({
-      num_vars <- names(df())[sapply(df(), is.numeric)]
-      updateSelectInput(session, "vars", choices = num_vars, selected = num_vars)
-    })
+    repopulate_numeric_selector <- function() {
+      data <- isolate(df())
+      if (is.null(data)) return()
+
+      num_vars <- names(data)[vapply(data, is.numeric, logical(1))]
+      previous <- isolate(input$vars)
+      selected <- intersect(previous %||% character(), num_vars)
+      if (length(selected) == 0) {
+        selected <- num_vars
+      }
+
+      updateSelectInput(session, "vars", choices = num_vars, selected = selected)
+    }
+
+    observeEvent(df(), {
+      repopulate_numeric_selector()
+    }, ignoreNULL = FALSE)
+
+    session$onFlushed(function() {
+      repopulate_numeric_selector()
+    }, once = FALSE)
 
     run_pca_on_subset <- function(subset_data, selected_vars) {
       if (is.null(subset_data) || nrow(subset_data) == 0) {


### PR DESCRIPTION
## Summary
- repopulate the PCA numeric variable selector whenever the module reloads
- keep the pairwise correlation numeric selector in sync with the available numeric columns across tab switches

## Testing
- not run (UI change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9bbcb170832bae3d1c5b086eff50)