### PR TITLE
Remove unused regression table formatter

### DIFF
--- a/R/regression_analysis_shared.R
+++ b/R/regression_analysis_shared.R
@@ -413,35 +413,3 @@ write_lm_docx <- function(model, file, subtitle = NULL) {
   print(doc, target = file)
 }
 
-# ===============================================================
-# 🧾 Helper: format regression table in journal style
-# ===============================================================
-format_regression_table <- function(df, bold_p = TRUE) {
-  
-  ft <- flextable(df)
-  ft <- fontsize(ft, part = "all", size = 10)
-  ft <- bold(ft, part = "header", bold = TRUE)
-  ft <- color(ft, part = "header", color = "black")
-  ft <- align(ft, align = "center", part = "all")
-  ft <- border_remove(ft)
-  
-  black <- fp_border(color = "black", width = 1)
-  ft <- border(ft, part = "header", border.top = black)
-  ft <- border(ft, part = "header", border.bottom = black)
-  if (nrow(df) > 0) {
-    ft <- border(ft, i = nrow(df), part = "body", border.bottom = black)
-  }
-
-  if (bold_p && "Pr(>F)" %in% names(df)) {
-    sig_rows <- which(df[["Pr(>F)"]] < 0.05)
-    if (length(sig_rows) > 0) ft <- bold(ft, i = sig_rows, j = "Pr(>F)", bold = TRUE)
-  }
-  if (bold_p && "Pr(>|t|)" %in% names(df)) {
-    sig_rows <- which(df[["Pr(>|t|)"]] < 0.05)
-    if (length(sig_rows) > 0) ft <- bold(ft, i = sig_rows, j = "Pr(>|t|)", bold = TRUE)
-  }
-
-  ft <- set_table_properties(ft, layout = "autofit", width = 0.9)
-  ft <- padding(ft, padding.top = 2, padding.bottom = 2, padding.left = 2, padding.right = 2)
-  ft
-}

--- a/whole_app.txt
+++ b/whole_app.txt
@@ -7058,38 +7058,6 @@ write_lm_docx <- function(model, file, subtitle = NULL) {
   print(doc, target = file)
 }
 
-# ===============================================================
-# 🧾 Helper: format regression table in journal style
-# ===============================================================
-format_regression_table <- function(df, bold_p = TRUE) {
-  
-  ft <- flextable(df)
-  ft <- fontsize(ft, part = "all", size = 10)
-  ft <- bold(ft, part = "header", bold = TRUE)
-  ft <- color(ft, part = "header", color = "black")
-  ft <- align(ft, align = "center", part = "all")
-  ft <- border_remove(ft)
-  
-  black <- fp_border(color = "black", width = 1)
-  ft <- border(ft, part = "header", border.top = black)
-  ft <- border(ft, part = "header", border.bottom = black)
-  if (nrow(df) > 0) {
-    ft <- border(ft, i = nrow(df), part = "body", border.bottom = black)
-  }
-
-  if (bold_p && "Pr(>F)" %in% names(df)) {
-    sig_rows <- which(df[["Pr(>F)"]] < 0.05)
-    if (length(sig_rows) > 0) ft <- bold(ft, i = sig_rows, j = "Pr(>F)", bold = TRUE)
-  }
-  if (bold_p && "Pr(>|t|)" %in% names(df)) {
-    sig_rows <- which(df[["Pr(>|t|)"]] < 0.05)
-    if (length(sig_rows) > 0) ft <- bold(ft, i = sig_rows, j = "Pr(>|t|)", bold = TRUE)
-  }
-
-  ft <- set_table_properties(ft, layout = "autofit", width = 0.9)
-  ft <- padding(ft, padding.top = 2, padding.bottom = 2, padding.left = 2, padding.right = 2)
-  ft
-}# ===============================================================
 # 🔁 Multi-Response Selector Module
 # ===============================================================
 


### PR DESCRIPTION
## Summary
- remove the unused `format_regression_table()` helper from the shared regression utilities
- drop the matching unused helper from the generated `whole_app.txt` snapshot to keep the bundle in sync

## Testing
- not run (R runtime unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9c633078832ba92e600d59b196df)