### PR TITLE
Replace onFlushed usage with deferred numeric updates

### DIFF
--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -143,6 +143,16 @@ sync_numeric_input <- function(session, input_id, current_value, target_value) {
     return(invisible(FALSE))
   }
 
+  schedule_update <- function(value) {
+    shiny::later(
+      0,
+      function() {
+        updateNumericInput(session, input_id, value = value)
+      },
+      session = session
+    )
+  }
+
   target_int <- suppressWarnings(as.integer(target_value[1]))
   if (is.na(target_int)) {
     return(invisible(FALSE))
@@ -162,9 +172,7 @@ sync_numeric_input <- function(session, input_id, current_value, target_value) {
 
   if (missing_current) {
     assign(key, list(value = target_int, auto = TRUE), envir = state)
-    session$onFlushed(function() {
-      updateNumericInput(session, input_id, value = target_int)
-    }, once = TRUE)
+    schedule_update(target_int)
     return(invisible(TRUE))
   }
 
@@ -175,9 +183,7 @@ sync_numeric_input <- function(session, input_id, current_value, target_value) {
 
   if (isTRUE(entry$auto) && !identical(current_int, target_int)) {
     assign(key, list(value = target_int, auto = TRUE), envir = state)
-    session$onFlushed(function() {
-      updateNumericInput(session, input_id, value = target_int)
-    }, once = TRUE)
+    schedule_update(target_int)
     return(invisible(TRUE))
   }
 


### PR DESCRIPTION
## Summary
- replace the `session$onFlushed` callbacks used by the numeric sync helper with `shiny::later`
- keep numeric input updates deferred without relying on `onFlushed`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9f9ecfec832ba7aa0b71fe0375c3)