### PR TITLE
Fix level order UI reacting to random effect selection

### DIFF
--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -73,9 +73,6 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
 
       df <- data()
       fac_vars <- input$fixed
-      if (engine == "lmm" && !is.null(input$random) && nzchar(input$random)) {
-        fac_vars <- unique(c(fac_vars, input$random))
-      }
 
       if (length(fac_vars) == 0) return(NULL)
 


### PR DESCRIPTION
## Summary
- prevent the level-order UI from including the random-effect selection when configuring categorical predictors

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa1845a88832bb58ee2522f362396)