### PR TITLE
Add optional value labels to barplot visualizations

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -21,6 +21,14 @@ visualize_oneway_ui <- function(id) {
       ),
       hr(),
       uiOutput(ns("layout_controls")),
+      conditionalPanel(
+        condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
+        checkboxInput(
+          ns("show_bar_labels"),
+          "Show value labels on bars",
+          value = FALSE
+        )
+      ),
       fluidRow(
         column(6, numericInput(ns("plot_width"), "Subplot width (px)", value = 400, min = 200, max = 1200, step = 50)),
         column(6, numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50))
@@ -126,7 +134,8 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
           info,
           layout_values = layout_inputs,
           line_colors = colors,
-          posthoc_all = posthoc_data
+          posthoc_all = posthoc_data,
+          show_value_labels = isTRUE(input$show_bar_labels)
         )
       )
 
@@ -141,7 +150,8 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
         input$strata_cols,
         input$resp_rows,
         input$resp_cols,
-        custom_colors()
+        custom_colors(),
+        input$show_bar_labels
       ),
       {
         info <- model_info()

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -21,6 +21,14 @@ visualize_twoway_ui <- function(id) {
       ),
       hr(),
       uiOutput(ns("layout_controls")),
+      conditionalPanel(
+        condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
+        checkboxInput(
+          ns("show_bar_labels"),
+          "Show value labels on bars",
+          value = FALSE
+        )
+      ),
       fluidRow(
         column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 1200, step = 50)),
         column(6, numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50))
@@ -138,7 +146,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
           info,
           layout_values = layout_inputs,
           line_colors = line_colors,
-          posthoc_all = posthoc_data
+          posthoc_all = posthoc_data,
+          show_value_labels = isTRUE(input$show_bar_labels)
         )
       )
 
@@ -153,7 +162,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
         input$strata_cols,
         input$resp_rows,
         input$resp_cols,
-        custom_colors()
+        custom_colors(),
+        input$show_bar_labels
       ),
       {
         info <- model_info()


### PR DESCRIPTION
## Summary
- add UI controls so barplot visualizations can toggle value labels
- render optional bar value annotations for ANOVA and descriptive categorical barplots with spacing and formatting adjustments

## Testing
- Not run (Rscript not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb375a914832baf17404f7db0667a)