### PR TITLE
Fix two-way ANOVA bar label positioning

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1212,7 +1212,8 @@ build_bar_plot_panel <- function(stats_df,
           y = label_y,
           label = label_text,
           vjust = label_vjust,
-          fill = NULL
+          fill = NULL,
+          group = !!sym(factor2)
         ),
         position = dodge,
         color = "gray20",


### PR DESCRIPTION
## Summary
- ensure value labels on two-way ANOVA bar plots respect the grouped dodge so each bar receives its label

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb830a430832b8b7f2733a33bbdee)