### PR TITLE
Fix categorical barplot checkboxes not responding on first click

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -105,15 +105,8 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
 
     cached_plot_info <- reactiveVal(NULL)
     cache_ready <- reactiveVal(FALSE)
-    skip_auto_invalidations <- reactiveVal(0L)
 
     invalidate_cache <- function() {
-      remaining <- skip_auto_invalidations()
-      if (remaining > 0L) {
-        skip_auto_invalidations(remaining - 1L)
-        return(invisible(FALSE))
-      }
-
       cached_plot_info(NULL)
       cache_ready(FALSE)
       invisible(TRUE)
@@ -134,10 +127,16 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
     )
 
     observeEvent(input$resp_rows, {
+      if (isTRUE(consume_pending_numeric_update(session, "resp_rows"))) {
+        return()
+      }
       invalidate_cache()
     }, ignoreNULL = FALSE)
 
     observeEvent(input$resp_cols, {
+      if (isTRUE(consume_pending_numeric_update(session, "resp_cols"))) {
+        return()
+      }
       invalidate_cache()
     }, ignoreNULL = FALSE)
 
@@ -201,17 +200,8 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       cols <- info$defaults$cols
       if (is.null(rows) || is.null(cols)) return()
 
-      updates <- 0L
-      if (isTRUE(sync_numeric_input(session, "resp_rows", input$resp_rows, rows))) {
-        updates <- updates + 1L
-      }
-      if (isTRUE(sync_numeric_input(session, "resp_cols", input$resp_cols, cols))) {
-        updates <- updates + 1L
-      }
-
-      if (updates > 0L) {
-        skip_auto_invalidations(skip_auto_invalidations() + updates)
-      }
+      sync_numeric_input(session, "resp_rows", input$resp_rows, rows)
+      sync_numeric_input(session, "resp_cols", input$resp_cols, cols)
     }, ignoreNULL = FALSE)
 
     output$grid_warning <- renderUI({


### PR DESCRIPTION
## Summary
- adjust numeric input synchronization to track pending auto updates instead of a global skip counter
- avoid clearing cached plots when auto grid updates fire so other controls like categorical barplot checkboxes respond immediately
- reuse the pending-update guard across categorical and numeric visualization modules

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb7b2daac832bb2a10b014d498fa7)