### PR TITLE
Preserve selected ANOVA plot type after rerun

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -68,6 +68,18 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       last_plot_type(input$plot_type)
     }, ignoreInit = TRUE)
 
+    observeEvent(model_info(), {
+      selected <- isolate(last_plot_type())
+      if (is.null(selected)) {
+        return()
+      }
+
+      current <- isolate(input$plot_type)
+      if (!identical(current, selected)) {
+        updateSelectInput(session, "plot_type", selected = selected)
+      }
+    }, ignoreNULL = TRUE)
+
     cached_results <- reactiveValues(plots = list())
 
     compute_empty_result <- function(message = NULL) {


### PR DESCRIPTION
## Summary
- ensure the one-way ANOVA visualization module restores the previously selected plot type after analyses rerun

## Testing
- Rscript -e 'testthat::test_dir("tests")' *(fails: command not found: Rscript)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb97fa524832b912879c19fff9fe7)