### PR TITLE
Align safe error messaging across modules

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -422,14 +422,14 @@ print_anova_summary_and_posthoc <- function(model_entry, factors) {
   }
 
   if (!is.null(model_entry$error)) {
-    cat("Model fitting failed:\n", model_entry$error, "\n", sep = "")
+    cat(format_safe_error_message("Model fitting failed", model_entry$error), "\n", sep = "")
     return(invisible(NULL))
   }
 
   model_obj <- model_entry$model
   results <- prepare_anova_outputs(model_obj, factors)
   if (!is.null(results$error)) {
-    cat("ANOVA computation failed:\n", results$error, "\n", sep = "")
+    cat(format_safe_error_message("ANOVA computation failed", results$error), "\n", sep = "")
     return(invisible(NULL))
   }
   if (is.null(results$anova_object)) {
@@ -444,7 +444,15 @@ print_anova_summary_and_posthoc <- function(model_entry, factors) {
     for (factor_nm in names(results$posthoc_details)) {
       details <- results$posthoc_details[[factor_nm]]
       if (!is.null(details$error)) {
-        cat("\nPost-hoc Tukey comparisons for", factor_nm, "failed:", details$error, "\n")
+        cat(
+          "\n",
+          format_safe_error_message(
+            paste("Post-hoc Tukey comparisons for", factor_nm, "failed"),
+            details$error
+          ),
+          "\n",
+          sep = ""
+        )
       } else if (!is.null(details$table)) {
         cat("\nPost-hoc Tukey comparisons for", factor_nm, ":\n")
         print(details$table)

--- a/R/error_helpers.R
+++ b/R/error_helpers.R
@@ -1,0 +1,27 @@
+format_safe_error_message <- function(title, details = NULL) {
+  if (is.null(title) || !nzchar(title)) {
+    title <- "Error"
+  }
+
+  if (inherits(details, "condition")) {
+    details <- conditionMessage(details)
+  }
+
+  if (is.null(details)) {
+    details <- ""
+  }
+
+  if (is.list(details)) {
+    details <- unlist(details, recursive = TRUE, use.names = FALSE)
+  }
+
+  details <- vapply(details, as.character, character(1), USE.NAMES = FALSE)
+  details <- trimws(details)
+  details <- details[nzchar(details)]
+
+  if (length(details) == 0) {
+    return(paste0(title, ":"))
+  }
+
+  paste0(title, ":\n", paste(details, collapse = "\n"))
+}

--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -63,7 +63,7 @@ upload_server <- function(id) {
         processed <- safe_preprocess_uploaded_table(data)
         if (!is.null(processed$error)) {
           output$validation_msg <- renderText(
-            paste("❌ Error preparing example dataset:", conditionMessage(processed$error))
+            format_safe_error_message("Error preparing example dataset", processed$error)
           )
           return()
         }
@@ -145,10 +145,7 @@ upload_server <- function(id) {
 
         if (!is.null(safe_result$error)) {
           output$validation_msg <- renderText(
-            paste(
-              "❌ Error converting wide format:",
-              conditionMessage(safe_result$error)
-            )
+            format_safe_error_message("Error converting wide format", safe_result$error)
           )
           return()
         }
@@ -174,7 +171,7 @@ upload_server <- function(id) {
       processed <- safe_preprocess_uploaded_table(data)
       if (!is.null(processed$error)) {
         output$validation_msg <- renderText(
-          paste("❌ Error preparing data:", conditionMessage(processed$error))
+          format_safe_error_message("Error preparing data", processed$error)
         )
         return()
       }

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -86,6 +86,7 @@ pca_server <- function(id, filtered_data) {
           model = NULL,
           data = plot_data,
           message = conditionMessage(model$error),
+          message_title = "PCA computation failed",
           original_n = original_n,
           used_n = used_n,
           excluded_n = excluded_n,
@@ -144,11 +145,14 @@ pca_server <- function(id, filtered_data) {
         }
 
         if (!is.null(entry) && !is.null(entry$message) && nzchar(entry$message)) {
-          message <- entry$message
+          if (!is.null(entry$message_title)) {
+            cat(format_safe_error_message(entry$message_title, entry$message))
+          } else {
+            cat(entry$message)
+          }
         } else {
-          message <- "Not enough data to compute PCA."
+          cat("Not enough data to compute PCA.")
         }
-        cat(message)
         return(invisible())
       }
 
@@ -196,11 +200,14 @@ pca_server <- function(id, filtered_data) {
 
         if (is.null(entry) || is.null(entry$model)) {
           if (!is.null(entry) && !is.null(entry$message) && nzchar(entry$message)) {
-            message <- entry$message
+            if (!is.null(entry$message_title)) {
+              cat(format_safe_error_message(entry$message_title, entry$message), "\n", sep = "")
+            } else {
+              cat(entry$message, "\n", sep = "")
+            }
           } else {
-            message <- "Not enough data to compute PCA."
+            cat("Not enough data to compute PCA.\n")
           }
-          cat(message, "\n", sep = "")
           return()
         }
 

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -305,20 +305,20 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
               tagList(
                 verbatimTextOutput(ns(paste0("summary_", idx, "_", j))),
                 br(),
-              h5("Diagnostics"),
-              fluidRow(
-                column(6, plotOutput(ns(paste0("resid_", idx, "_", j)))),
-                column(6, plotOutput(ns(paste0("qq_", idx, "_", j))))
-              ),
-              br(),
-              downloadButton(ns(paste0("download_", idx, "_", j)), "Download results", style = "width: 100%;")
-            )
-          } else {
-            div(
-              class = "alert alert-warning",
-              if (!is.null(stratum$error)) stratum$error else "Model fitting failed."
-            )
-          }
+                h5("Diagnostics"),
+                fluidRow(
+                  column(6, plotOutput(ns(paste0("resid_", idx, "_", j)))),
+                  column(6, plotOutput(ns(paste0("qq_", idx, "_", j))))
+                ),
+                br(),
+                downloadButton(ns(paste0("download_", idx, "_", j)), "Download results", style = "width: 100%;")
+              )
+            } else {
+              div(
+                class = "alert alert-warning",
+                tags$pre(format_safe_error_message("Model fitting failed", stratum$error))
+              )
+            }
 
           tabPanel(title = label, content)
         })
@@ -342,7 +342,14 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       if (!is.null(error_resps) && length(error_resps) > 0) {
         error_items <- lapply(error_resps, function(resp) {
           err <- mod$errors[[resp]]
-          tags$li(tags$strong(resp), ": ", if (!is.null(err)) err else "Model fitting failed.")
+          tags$li(
+            tags$pre(
+              format_safe_error_message(
+                paste("Model fitting failed for", resp),
+                if (!is.null(err)) err else ""
+              )
+            )
+          )
         })
         error_block <- div(
           class = "alert alert-warning",


### PR DESCRIPTION
## Summary
- add a shared helper to format error output from purrr::safely wrappers
- update ANOVA, regression, upload, and PCA modules to present safe errors with the shared layout

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbc9f521c832b956e380952687f05)