### PR TITLE
Add contextual tooltips across app widgets

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -14,8 +14,14 @@ one_way_anova_ui <- function(id) {
       ),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Show results", width = "100%")),
-        column(6, downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"))
+        column(6, with_help_tooltip(
+          actionButton(ns("run"), "Show results", width = "100%"),
+          "Help: Run the ANOVA using the selected response and group variable."
+        )),
+        column(6, with_help_tooltip(
+          downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"),
+          "Help: Export the ANOVA summaries, post-hoc tests, and diagnostics."
+        ))
       )
     ),
     results = tagList(
@@ -45,11 +51,14 @@ one_way_anova_server <- function(id, filtered_data) {
 
       tagList(
         multi_response_ui(ns("response")),
-        selectInput(
-          ns("group"),
-          "Categorical predictor:",
-          choices = cat_cols,
-          selected = if (length(cat_cols) > 0) cat_cols[1] else NULL
+        with_help_tooltip(
+          selectInput(
+            ns("group"),
+            "Categorical predictor:",
+            choices = cat_cols,
+            selected = if (length(cat_cols) > 0) cat_cols[1] else NULL
+          ),
+          "Help: Choose the grouping variable that defines the comparison categories."
         )
       )
     })
@@ -62,12 +71,15 @@ one_way_anova_server <- function(id, filtered_data) {
     output$level_order <- renderUI({
       req(df(), input$group)
       levels <- unique(as.character(df()[[input$group]]))
-      selectInput(
-        ns("order"),
-        "Order of levels (first = reference):",
-        choices = levels,
-        selected = levels,
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("order"),
+          "Order of levels (first = reference):",
+          choices = levels,
+          selected = levels,
+          multiple = TRUE
+        ),
+        "Help: Arrange the group levels; the first level is used as the reference in outputs."
       )
     })
     

--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -10,32 +10,47 @@ visualize_oneway_ui <- function(id) {
       h4("Step 4 — Visualize one-way ANOVA"),
       p("Select visualization type and adjust subplot layout, axis scaling, and figure size."),
       hr(),
-      selectInput(
-        ns("plot_type"),
-        label = "Select visualization type:",
-        choices = c(
-          "Lineplots (mean ± SE)" = "lineplot_mean_se",
-          "Barplots (mean ± SE)"  = "barplot_mean_se"
+      with_help_tooltip(
+        selectInput(
+          ns("plot_type"),
+          label = "Select visualization type:",
+          choices = c(
+            "Lineplots (mean ± SE)" = "lineplot_mean_se",
+            "Barplots (mean ± SE)"  = "barplot_mean_se"
+          ),
+          selected = "lineplot_mean_se"
         ),
-        selected = "lineplot_mean_se"
+        "Help: Pick the chart style you prefer for comparing group means and error bars."
       ),
       hr(),
       uiOutput(ns("layout_controls")),
       conditionalPanel(
         condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
-        checkboxInput(
-          ns("show_bar_labels"),
-          "Show value labels on bars",
-          value = FALSE
+        with_help_tooltip(
+          checkboxInput(
+            ns("show_bar_labels"),
+            "Show value labels on bars",
+            value = FALSE
+          ),
+          "Help: Turn on labels to display the mean value on top of each bar."
         )
       ),
       fluidRow(
-        column(6, numericInput(ns("plot_width"), "Subplot width (px)", value = 400, min = 200, max = 1200, step = 50)),
-        column(6, numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50))
+        column(6, with_help_tooltip(
+          numericInput(ns("plot_width"), "Subplot width (px)", value = 400, min = 200, max = 1200, step = 50),
+          "Help: Adjust how wide each subplot should be in pixels."
+        )),
+        column(6, with_help_tooltip(
+          numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50),
+          "Help: Adjust how tall each subplot should be in pixels."
+        ))
       ),
       add_color_customization_ui(ns, multi_group = FALSE),
       hr(),
-      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+      with_help_tooltip(
+        downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+        "Help: Save the current figure as an image file."
+      )
     ),
     mainPanel(
       width = 8,

--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -12,24 +12,30 @@ build_anova_layout_controls <- function(ns, input, info) {
       fluidRow(
         column(
           width = 6,
-          numericInput(
-            ns("strata_rows"),
-            "Grid rows",
-            value = isolate(if (is.null(input$strata_rows)) NA else input$strata_rows),
-            min = 1,
-            max = 10,
-            step = 1
+          with_help_tooltip(
+            numericInput(
+              ns("strata_rows"),
+              "Grid rows",
+              value = isolate(if (is.null(input$strata_rows)) NA else input$strata_rows),
+              min = 1,
+              max = 10,
+              step = 1
+            ),
+            "Help: Set how many rows of plots to use when displaying different strata."
           )
         ),
         column(
           width = 6,
-          numericInput(
-            ns("strata_cols"),
-            "Grid columns",
-            value = isolate(if (is.null(input$strata_cols)) NA else input$strata_cols),
-            min = 1,
-            max = 10,
-            step = 1
+          with_help_tooltip(
+            numericInput(
+              ns("strata_cols"),
+              "Grid columns",
+              value = isolate(if (is.null(input$strata_cols)) NA else input$strata_cols),
+              min = 1,
+              max = 10,
+              step = 1
+            ),
+            "Help: Set how many columns of plots to use when displaying different strata."
           )
         )
       )
@@ -44,24 +50,30 @@ build_anova_layout_controls <- function(ns, input, info) {
       fluidRow(
         column(
           width = 6,
-          numericInput(
-            ns("resp_rows"),
-            "Grid rows",
-            value = isolate(if (is.null(input$resp_rows)) NA else input$resp_rows),
-            min = 1,
-            max = 10,
-            step = 1
+          with_help_tooltip(
+            numericInput(
+              ns("resp_rows"),
+              "Grid rows",
+              value = isolate(if (is.null(input$resp_rows)) NA else input$resp_rows),
+              min = 1,
+              max = 10,
+              step = 1
+            ),
+            "Help: Set the number of plot rows when multiple responses are shown together."
           )
         ),
         column(
           width = 6,
-          numericInput(
-            ns("resp_cols"),
-            "Grid columns",
-            value = isolate(if (is.null(input$resp_cols)) NA else input$resp_cols),
-            min = 1,
-            max = 10,
-            step = 1
+          with_help_tooltip(
+            numericInput(
+              ns("resp_cols"),
+              "Grid columns",
+              value = isolate(if (is.null(input$resp_cols)) NA else input$resp_cols),
+              min = 1,
+              max = 10,
+              step = 1
+            ),
+            "Help: Set the number of plot columns when multiple responses are shown together."
           )
         )
       )

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -15,8 +15,14 @@ two_way_anova_ui <- function(id) {
       ),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Show results", width = "100%")),
-        column(6, downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"))
+        column(6, with_help_tooltip(
+          actionButton(ns("run"), "Show results", width = "100%"),
+          "Help: Fit the two-way ANOVA with the selected factors and responses."
+        )),
+        column(6, with_help_tooltip(
+          downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"),
+          "Help: Save all ANOVA tables, post-hoc results, and diagnostics to disk."
+        ))
       )
     ),
     results = tagList(
@@ -46,17 +52,23 @@ two_way_anova_server <- function(id, filtered_data) {
 
       tagList(
         multi_response_ui(ns("response")),
-        selectInput(
-          ns("factor1"),
-          "Categorical predictor 1 (x-axis):",
-          choices = cat_cols,
-          selected = if (length(cat_cols) > 0) cat_cols[1] else NULL
+        with_help_tooltip(
+          selectInput(
+            ns("factor1"),
+            "Categorical predictor 1 (x-axis):",
+            choices = cat_cols,
+            selected = if (length(cat_cols) > 0) cat_cols[1] else NULL
+          ),
+          "Help: Select the factor for the x-axis groups in the interaction plot."
         ),
-        selectInput(
-          ns("factor2"),
-          "Categorical predictor 2 (lines):",
-          choices = cat_cols,
-          selected = if (length(cat_cols) > 1) cat_cols[2] else NULL
+        with_help_tooltip(
+          selectInput(
+            ns("factor2"),
+            "Categorical predictor 2 (lines):",
+            choices = cat_cols,
+            selected = if (length(cat_cols) > 1) cat_cols[2] else NULL
+          ),
+          "Help: Select the factor for the lines in the interaction plot."
         )
       )
     })
@@ -69,24 +81,30 @@ two_way_anova_server <- function(id, filtered_data) {
     output$level_order_1 <- renderUI({
       req(df(), input$factor1)
       levels1 <- unique(as.character(df()[[input$factor1]]))
-      selectInput(
-        ns("order1"),
-        paste("Order of levels (first = reference):", input$factor1, "(x-axis)"),
-        choices = levels1,
-        selected = levels1,
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("order1"),
+          paste("Order of levels (first = reference):", input$factor1, "(x-axis)"),
+          choices = levels1,
+          selected = levels1,
+          multiple = TRUE
+        ),
+        sprintf("Help: Arrange the levels of %s for the x-axis; the first level is the reference.", input$factor1)
       )
     })
     
     output$level_order_2 <- renderUI({
       req(df(), input$factor2)
       levels2 <- unique(as.character(df()[[input$factor2]]))
-      selectInput(
-        ns("order2"),
-        paste("Order of levels (first = reference):", input$factor2, "(lines)"),
-        choices = levels2,
-        selected = levels2,
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("order2"),
+          paste("Order of levels (first = reference):", input$factor2, "(lines)"),
+          choices = levels2,
+          selected = levels2,
+          multiple = TRUE
+        ),
+        sprintf("Help: Arrange the levels of %s for the line colours; the first level is the reference.", input$factor2)
       )
     })
     

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -10,32 +10,47 @@ visualize_twoway_ui <- function(id) {
       h4("Step 4 — Visualize two-way ANOVA"),
       p("Select visualization type and adjust subplot layout, axis scaling, and figure size."),
       hr(),
-      selectInput(
-        ns("plot_type"),
-        label = "Select visualization type:",
-        choices = c(
-          "Lineplots (mean ± SE)" = "lineplot_mean_se",
-          "Barplots (mean ± SE)"  = "barplot_mean_se"
+      with_help_tooltip(
+        selectInput(
+          ns("plot_type"),
+          label = "Select visualization type:",
+          choices = c(
+            "Lineplots (mean ± SE)" = "lineplot_mean_se",
+            "Barplots (mean ± SE)"  = "barplot_mean_se"
+          ),
+          selected = "lineplot_mean_se"
         ),
-        selected = "lineplot_mean_se"
+        "Help: Pick the chart style you prefer for viewing group means and uncertainty."
       ),
       hr(),
       uiOutput(ns("layout_controls")),
       conditionalPanel(
         condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
-        checkboxInput(
-          ns("show_bar_labels"),
-          "Show value labels on bars",
-          value = FALSE
+        with_help_tooltip(
+          checkboxInput(
+            ns("show_bar_labels"),
+            "Show value labels on bars",
+            value = FALSE
+          ),
+          "Help: Turn on labels to display the mean value on each bar."
         )
       ),
       fluidRow(
-        column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 1200, step = 50)),
-        column(6, numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50))
+        column(6, with_help_tooltip(
+          numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 1200, step = 50),
+          "Help: Set how wide each subplot should be in pixels."
+        )),
+        column(6, with_help_tooltip(
+          numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 1200, step = 50),
+          "Help: Set how tall each subplot should be in pixels."
+        ))
       ),
       add_color_customization_ui(ns, multi_group = TRUE),
       hr(),
-      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+      with_help_tooltip(
+        downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+        "Help: Save the current figure as an image file."
+      )
     ),
     mainPanel(
       width = 8,

--- a/R/custom_widgets.R
+++ b/R/custom_widgets.R
@@ -148,3 +148,15 @@ color_dropdown_input <- function(ns, id = "color_choice", palette = basic_color_
     )))
   )
 }
+
+# ===============================================================
+# 🛈 Consistent tooltip helper for UI widgets
+# ===============================================================
+
+with_help_tooltip <- function(widget, text) {
+  tags$div(
+    class = "ta-help-tooltip",
+    title = text,
+    widget
+  )
+}

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -13,8 +13,14 @@ descriptive_ui <- function(id) {
       ),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Show summary", width = "100%")),
-        column(6, downloadButton(ns("download_summary"), "Download summary", style = "width: 100%;"))
+        column(6, with_help_tooltip(
+          actionButton(ns("run"), "Show summary", width = "100%"),
+          "Help: Calculate the descriptive statistics for the selected variables."
+        )),
+        column(6, with_help_tooltip(
+          downloadButton(ns("download_summary"), "Download summary", style = "width: 100%;"),
+          "Help: Save the displayed summary as a text file for later reference."
+        ))
       ),
       hr()
     ),
@@ -39,8 +45,14 @@ descriptive_server <- function(id, filtered_data) {
       num_cols <- names(data)[vapply(data, is.numeric, logical(1))]
       
       tagList(
-        selectInput(ns("cat_vars"), label = "Categorical variables:", choices = cat_cols, selected = cat_cols, multiple = TRUE),
-        selectInput(ns("num_vars"), label = "Numeric variables:", choices = num_cols, selected = num_cols, multiple = TRUE)
+        with_help_tooltip(
+          selectInput(ns("cat_vars"), label = "Categorical variables:", choices = cat_cols, selected = cat_cols, multiple = TRUE),
+          "Help: Choose the group variables whose counts and proportions you want to inspect."
+        ),
+        with_help_tooltip(
+          selectInput(ns("num_vars"), label = "Numeric variables:", choices = num_cols, selected = num_cols, multiple = TRUE),
+          "Help: Choose the numeric measurements you want to summarise (mean, SD, etc.)."
+        )
       )
     })
     

--- a/R/descriptive_visualize.R
+++ b/R/descriptive_visualize.R
@@ -10,18 +10,21 @@ visualize_descriptive_ui <- function(id) {
       h4("Step 5 — Visualize descriptive statistics"),
       p("Explore distributions, variability, and normality across variables."),
       hr(),
-      selectInput(
-        ns("plot_type"),
-        label = "Select visualization type:",
-        choices = c(
-          "Categorical barplots" = "categorical",
-          "Numeric boxplots"          = "boxplots",
-          "Numeric histograms"        = "histograms",
-          "CV (%)"                    = "cv",
-          "Outlier counts"            = "outliers",
-          "Missingness (%)"           = "missing"
+      with_help_tooltip(
+        selectInput(
+          ns("plot_type"),
+          label = "Select visualization type:",
+          choices = c(
+            "Categorical barplots" = "categorical",
+            "Numeric boxplots"          = "boxplots",
+            "Numeric histograms"        = "histograms",
+            "CV (%)"                    = "cv",
+            "Outlier counts"            = "outliers",
+            "Missingness (%)"           = "missing"
+          ),
+          selected = "categorical"
         ),
-        selected = "categorical"
+        "Help: Choose the descriptive chart that best answers your question."
       ),
       hr(),
       uiOutput(ns("sub_controls"))  # controls from active submodule

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -5,39 +5,60 @@
 visualize_categorical_barplots_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    checkboxInput(ns("show_proportions"), "Show proportions instead of counts", FALSE),
-    checkboxInput(ns("show_value_labels"), "Show value labels on bars", FALSE),
+    with_help_tooltip(
+      checkboxInput(ns("show_proportions"), "Show proportions instead of counts", FALSE),
+      "Help: Switch between raw counts and percentages for each category."
+    ),
+    with_help_tooltip(
+      checkboxInput(ns("show_value_labels"), "Show value labels on bars", FALSE),
+      "Help: Display the numeric value on top of each bar."
+    ),
     fluidRow(
-      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  400, 200, 2000, 50)),
-      column(6, numericInput(ns("plot_height"), "Subplot height (px)", 300, 200, 2000, 50))
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_width"),  "Subplot width (px)",  400, 200, 2000, 50),
+        "Help: Set the width of each categorical plot in pixels."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_height"), "Subplot height (px)", 300, 200, 2000, 50),
+        "Help: Set the height of each categorical plot in pixels."
+      ))
     ),
     fluidRow(
       column(
         6,
-        numericInput(
-          ns("resp_rows"),
-          "Grid rows",
-          value = NA,
-          min = 1,
-          max = 10,
-          step = 1
+        with_help_tooltip(
+          numericInput(
+            ns("resp_rows"),
+            "Grid rows",
+            value = NA,
+            min = 1,
+            max = 10,
+            step = 1
+          ),
+          "Help: Choose how many rows of plots to display when several charts are shown."
         )
       ),
       column(
         6,
-        numericInput(
-          ns("resp_cols"),
-          "Grid columns",
-          value = NA,
-          min = 1,
-          max = 10,
-          step = 1
+        with_help_tooltip(
+          numericInput(
+            ns("resp_cols"),
+            "Grid columns",
+            value = NA,
+            min = 1,
+            max = 10,
+            step = 1
+          ),
+          "Help: Choose how many columns of plots to display when several charts are shown."
         )
       )
     ),
     add_color_customization_ui(ns, multi_group = TRUE),
     hr(),
-    downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+    with_help_tooltip(
+      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+      "Help: Save the categorical barplots as an image file."
+    )
   )
 }
 

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -8,12 +8,21 @@ metric_panel_ui <- function(id, default_width = 400, default_height = 300,
   ns <- NS(id)
   tagList(
     fluidRow(
-      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  default_width, 200, 2000, 50)),
-      column(6, numericInput(ns("plot_height"), "Subplot height (px)", default_height, 200, 2000, 50))
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_width"),  "Subplot width (px)",  default_width, 200, 2000, 50),
+        "Help: Set the width of each metric panel in pixels."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_height"), "Subplot height (px)", default_height, 200, 2000, 50),
+        "Help: Set the height of each metric panel in pixels."
+      ))
     ),
     add_color_customization_ui(ns, multi_group = TRUE),
     hr(),
-    downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+    with_help_tooltip(
+      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+      "Help: Save the metric charts as an image file."
+    )
   )
 }
 

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -5,43 +5,64 @@
 visualize_numeric_boxplots_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    checkboxInput(ns("show_points"), "Show individual data points", TRUE),
-    checkboxInput(ns("show_outliers"), "Highlight boxplot outliers", FALSE),
+    with_help_tooltip(
+      checkboxInput(ns("show_points"), "Show individual data points", TRUE),
+      "Help: Add the raw observations on top of each boxplot."
+    ),
+    with_help_tooltip(
+      checkboxInput(ns("show_outliers"), "Highlight boxplot outliers", FALSE),
+      "Help: Highlight points that fall outside the typical range."
+    ),
     conditionalPanel(
       condition = sprintf("input['%s']", ns("show_outliers")),
       uiOutput(ns("outlier_label_ui"))
     ),
     fluidRow(
-      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  200, 200, 2000, 50)),
-      column(6, numericInput(ns("plot_height"), "Subplot height (px)", 800, 200, 2000, 50))
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_width"),  "Subplot width (px)",  200, 200, 2000, 50),
+        "Help: Control how wide each boxplot panel should be."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_height"), "Subplot height (px)", 800, 200, 2000, 50),
+        "Help: Control how tall each boxplot panel should be."
+      ))
     ),
     fluidRow(
       column(
         6,
-        numericInput(
-          ns("resp_rows"),
-          "Grid rows",
-          value = NA,
-          min = 1,
-          max = 10,
-          step = 1
+        with_help_tooltip(
+          numericInput(
+            ns("resp_rows"),
+            "Grid rows",
+            value = NA,
+            min = 1,
+            max = 10,
+            step = 1
+          ),
+          "Help: Choose how many rows of plots to display when multiple charts are shown."
         )
       ),
       column(
         6,
-        numericInput(
-          ns("resp_cols"),
-          "Grid columns",
-          value = NA,
-          min = 1,
-          max = 100,
-          step = 1
+        with_help_tooltip(
+          numericInput(
+            ns("resp_cols"),
+            "Grid columns",
+            value = NA,
+            min = 1,
+            max = 100,
+            step = 1
+          ),
+          "Help: Choose how many columns of plots to display when multiple charts are shown."
         )
       )
     ),
     add_color_customization_ui(ns, multi_group = TRUE),
     hr(),
-    downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+    with_help_tooltip(
+      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+      "Help: Save the boxplots as an image file."
+    )
   )
 }
 
@@ -126,11 +147,14 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         current <- ""
       }
 
-      selectInput(
-        ns("outlier_label"),
-        label = "Label outliers by:",
-        choices = c("None" = "", stats::setNames(cat_cols, cat_cols)),
-        selected = current
+      with_help_tooltip(
+        selectInput(
+          ns("outlier_label"),
+          label = "Label outliers by:",
+          choices = c("None" = "", stats::setNames(cat_cols, cat_cols)),
+          selected = current
+        ),
+        "Help: Choose a column to annotate the highlighted outliers."
       )
     })
 

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -5,18 +5,36 @@
 visualize_numeric_histograms_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    checkboxInput(ns("use_density"), "Show density instead of count", FALSE),
-    fluidRow(
-      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  400, 200, 2000, 50)),
-      column(6, numericInput(ns("plot_height"), "Subplot height (px)", 300, 200, 2000, 50))
+    with_help_tooltip(
+      checkboxInput(ns("use_density"), "Show density instead of count", FALSE),
+      "Help: Switch between showing counts or densities for each histogram."
     ),
     fluidRow(
-      column(6, numericInput(ns("resp_rows"), "Grid rows",    value = NA, min = 1, max = 10, step = 1)),
-      column(6, numericInput(ns("resp_cols"), "Grid columns", value = NA, min = 1, max = 10, step = 1))
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_width"),  "Subplot width (px)",  400, 200, 2000, 50),
+        "Help: Set the width of each histogram panel in pixels."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_height"), "Subplot height (px)", 300, 200, 2000, 50),
+        "Help: Set the height of each histogram panel in pixels."
+      ))
+    ),
+    fluidRow(
+      column(6, with_help_tooltip(
+        numericInput(ns("resp_rows"), "Grid rows",    value = NA, min = 1, max = 10, step = 1),
+        "Help: Choose how many rows of histograms to display when several charts are shown."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("resp_cols"), "Grid columns", value = NA, min = 1, max = 10, step = 1),
+        "Help: Choose how many columns of histograms to display when several charts are shown."
+      ))
     ),
     add_color_customization_ui(ns, multi_group = TRUE),
     hr(),
-    downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+    with_help_tooltip(
+      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+      "Help: Save the histograms as an image file."
+    )
   )
 }
 

--- a/R/module_analysis.R
+++ b/R/module_analysis.R
@@ -20,24 +20,27 @@ analysis_ui <- function(id) {
       ", ns("analysis_type"), ns("analysis_type")))),
       
       # --- Analysis type selector ---
-      selectInput(
-        ns("analysis_type"),
-        "Select analysis type:",
-        choices = list(
-          " " = "",
-          "Descriptive" = c("Descriptive Statistics" = "Descriptive Statistics"),
-          "Univariate" = c(
-            "One-way ANOVA" = "One-way ANOVA",
-            "Two-way ANOVA" = "Two-way ANOVA",
-            "Linear Model (LM)" = "Linear Model (LM)",
-            "Linear Mixed Model (LMM)" = "Linear Mixed Model (LMM)"
+      with_help_tooltip(
+        selectInput(
+          ns("analysis_type"),
+          "Select analysis type:",
+          choices = list(
+            " " = "",
+            "Descriptive" = c("Descriptive Statistics" = "Descriptive Statistics"),
+            "Univariate" = c(
+              "One-way ANOVA" = "One-way ANOVA",
+              "Two-way ANOVA" = "Two-way ANOVA",
+              "Linear Model (LM)" = "Linear Model (LM)",
+              "Linear Mixed Model (LMM)" = "Linear Mixed Model (LMM)"
+            ),
+            "Multivariate" = c(
+              "Pairwise Correlation" = "Pairwise Correlation",
+              "Principal Component Analysis (PCA)" = "PCA"
+            )
           ),
-          "Multivariate" = c(
-            "Pairwise Correlation" = "Pairwise Correlation",
-            "Principal Component Analysis (PCA)" = "PCA"
-          )
+          selected = ""
         ),
-        selected = ""
+        "Help: Choose the statistical method you want to run on the filtered data."
       ),
       
       hr(),

--- a/R/module_colors.R
+++ b/R/module_colors.R
@@ -21,7 +21,10 @@ add_color_customization_server <- function(ns, input, output, data, color_var_re
       tagList(
         br(),
         h5("Color"),
-        color_dropdown_input(ns, "single_color", basic_color_palette, ncol = 4)
+        with_help_tooltip(
+          color_dropdown_input(ns, "single_color", basic_color_palette, ncol = 4),
+          "Help: Choose the colour used for the entire plot."
+        )
       )
     } else {
       render_color_inputs(ns, data, color_var)

--- a/R/module_colors_helpers.R
+++ b/R/module_colors_helpers.R
@@ -19,12 +19,15 @@ render_color_inputs <- function(ns, data, color_var) {
       tags$div(
         style = "margin-bottom: 8px;",
         tags$label(lvls[i], style = "display:block; margin-bottom: 4px;"),
-        color_dropdown_input(
-          ns,
-          id = paste0("col_", color_var, "_", i),
-          palette = basic_color_palette,
-          ncol = 4,
-          selected = selected
+        with_help_tooltip(
+          color_dropdown_input(
+            ns,
+            id = paste0("col_", color_var, "_", i),
+            palette = basic_color_palette,
+            ncol = 4,
+            selected = selected
+          ),
+          sprintf("Help: Pick the colour that will represent %s in the plot.", lvls[i])
         )
       )
     })

--- a/R/module_filter.R
+++ b/R/module_filter.R
@@ -30,11 +30,14 @@ filter_server <- function(id, uploaded_data) {
     # --- 1. Column selector ---
     output$column_selector <- renderUI({
       req(df())
-      selectInput(
-        ns("columns"),
-        "Select columns to filter:",
-        choices = names(df()),
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("columns"),
+          "Select columns to filter:",
+          choices = names(df()),
+          multiple = TRUE
+        ),
+        "Help: Choose which variables you want to filter before running analyses."
       )
     })
     
@@ -51,33 +54,45 @@ filter_server <- function(id, uploaded_data) {
         fluidRow(
           column(
             6,
-            numericInput(
-              ns(paste0("min_", col)), paste(col, "(min)"),
-              value = rng[1], min = rng[1], max = rng[2], step = step_val
+            with_help_tooltip(
+              numericInput(
+                ns(paste0("min_", col)), paste(col, "(min)"),
+                value = rng[1], min = rng[1], max = rng[2], step = step_val
+              ),
+              sprintf("Help: Enter the smallest value to keep for %s.", col)
             )
           ),
           column(
             6,
-            numericInput(
-              ns(paste0("max_", col)), paste(col, "(max)"),
-              value = rng[2], min = rng[1], max = rng[2], step = step_val
+            with_help_tooltip(
+              numericInput(
+                ns(paste0("max_", col)), paste(col, "(max)"),
+                value = rng[2], min = rng[1], max = rng[2], step = step_val
+              ),
+              sprintf("Help: Enter the largest value to keep for %s.", col)
             )
           )
         )
       }
       
       make_logical_widget <- function(col) {
-        checkboxGroupInput(
-          ns(paste0("filter_", col)), label = col,
-          choices = c(TRUE, FALSE), selected = c(TRUE, FALSE), inline = TRUE
+        with_help_tooltip(
+          checkboxGroupInput(
+            ns(paste0("filter_", col)), label = col,
+            choices = c(TRUE, FALSE), selected = c(TRUE, FALSE), inline = TRUE
+          ),
+          sprintf("Help: Tick the logical values you want to keep for %s.", col)
         )
       }
       
       make_factor_widget <- function(col, x) {
         choices <- sort(unique(as.character(x)))
-        selectInput(
-          ns(paste0("filter_", col)), label = col,
-          choices = choices, multiple = TRUE, selected = choices
+        with_help_tooltip(
+          selectInput(
+            ns(paste0("filter_", col)), label = col,
+            choices = choices, multiple = TRUE, selected = choices
+          ),
+          sprintf("Help: Choose which categories should remain for %s.", col)
         )
       }
       

--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -10,22 +10,28 @@ upload_ui <- function(id) {
       h4("Step 1 — Upload data"),
       p("Choose whether to load the example dataset or upload your own Excel file."),
       hr(),
-      radioButtons(
-        ns("data_source"),
-        label = "Data source:",
-        choices = c(
-          "Example dataset" = "example",
-          "Upload (long format)" = "long",
-          "Upload (wide format)" = "wide"
+      with_help_tooltip(
+        radioButtons(
+          ns("data_source"),
+          label = "Data source:",
+          choices = c(
+            "Example dataset" = "example",
+            "Upload (long format)" = "long",
+            "Upload (wide format)" = "wide"
+          ),
+          selected = "example"
         ),
-        selected = "example"
+        "Help: Decide whether to explore the built-in example data or load your own table."
       ),
       uiOutput(ns("layout_example")),
       hr(),
-      fileInput(
-        ns("file"),
-        "Upload Excel file (.xlsx / .xls / .xlsm)",
-        accept = c(".xlsx", ".xls", ".xlsm")
+      with_help_tooltip(
+        fileInput(
+          ns("file"),
+          "Upload Excel file (.xlsx / .xls / .xlsm)",
+          accept = c(".xlsx", ".xls", ".xlsm")
+        ),
+        "Help: Provide the Excel workbook that stores your study measurements."
       ),
       uiOutput(ns("sheet_selector")),
       hr(),
@@ -121,7 +127,10 @@ upload_server <- function(id) {
       
       output$validation_msg <- renderText(paste("✅ File loaded:", input$file$name))
       output$sheet_selector <- renderUI(
-        selectInput(ns("sheet"), "Select sheet:", choices = sheets)
+        with_help_tooltip(
+          selectInput(ns("sheet"), "Select sheet:", choices = sheets),
+          "Help: Pick the worksheet inside your Excel file that contains the data."
+        )
       )
     }, ignoreInit = TRUE)
     
@@ -204,12 +213,15 @@ upload_server <- function(id) {
         tagList(
           h5("Ambiguous type columns"),
           lapply(few_level_nums, function(col) {
-            selectInput(
-              ns(paste0("type_", col)),
-              label = col,
-              choices = c("Numeric", "Categorical"),
-              selected = "Numeric",
-              width = "100%"
+            with_help_tooltip(
+              selectInput(
+                ns(paste0("type_", col)),
+                label = col,
+                choices = c("Numeric", "Categorical"),
+                selected = "Numeric",
+                width = "100%"
+              ),
+              "Help: Tell the app whether this column should be treated as numbers or as groups."
             )
           })
         )

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -6,15 +6,24 @@ ggpairs_ui <- function(id) {
   ns <- NS(id)
   list(
     config = tagList(
-      selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
+      with_help_tooltip(
+        selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
+        "Help: Choose which numeric columns to include in the correlation matrix."
+      ),
       tags$details(
         tags$summary(strong("Advanced options")),
         stratification_ui("strat", ns)
       ),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Show correlation matrix", width = "100%")),
-        column(6, downloadButton(ns("download_model"), "Download all results", style = "width: 100%;"))
+        column(6, with_help_tooltip(
+          actionButton(ns("run"), "Show correlation matrix", width = "100%"),
+          "Help: Calculate the correlation coefficients for the selected variables."
+        )),
+        column(6, with_help_tooltip(
+          downloadButton(ns("download_model"), "Download all results", style = "width: 100%;"),
+          "Help: Export the correlation matrices and any messages to a text file."
+        ))
       )
     ),
     results = tagList(

--- a/R/pairwise_correlation_visualize.R
+++ b/R/pairwise_correlation_visualize.R
@@ -10,11 +10,14 @@ visualize_ggpairs_ui <- function(id) {
       h4("Step 4 — Visualize pairwise correlation"),
       p("Visualize pairwise relationships and correlation coefficients among numeric variables."),
       hr(),
-      selectInput(
-        ns("plot_type"),
-        label = "Select visualization type:",
-        choices = c("Pairwise scatterplot matrix" = "GGPairs"),
-        selected = "GGPairs"
+      with_help_tooltip(
+        selectInput(
+          ns("plot_type"),
+          label = "Select visualization type:",
+          choices = c("Pairwise scatterplot matrix" = "GGPairs"),
+          selected = "GGPairs"
+        ),
+        "Help: Choose how to visualise the pairwise relationships between variables."
       ),
       hr(),
       uiOutput(ns("sub_controls"))

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -6,16 +6,31 @@ pairwise_correlation_visualize_ggpairs_ui <- function(id) {
   ns <- NS(id)
   tagList(
     fluidRow(
-      column(6, numericInput(ns("plot_width"),  "Subplot width (px)",  800, 200, 2000, 50)),
-      column(6, numericInput(ns("plot_height"), "Subplot height (px)", 600, 200, 2000, 50))
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_width"),  "Subplot width (px)",  800, 200, 2000, 50),
+        "Help: Set the width in pixels for each panel of the correlation matrix."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("plot_height"), "Subplot height (px)", 600, 200, 2000, 50),
+        "Help: Set the height in pixels for each panel of the correlation matrix."
+      ))
     ),
     fluidRow(
-      column(6, numericInput(ns("resp_rows"),    "Grid rows",    NA, 1, 10, 1)),
-      column(6, numericInput(ns("resp_cols"),    "Grid columns", NA, 1, 10, 1))
+      column(6, with_help_tooltip(
+        numericInput(ns("resp_rows"),    "Grid rows",    NA, 1, 10, 1),
+        "Help: Choose how many rows of panels to use when multiple strata are plotted."
+      )),
+      column(6, with_help_tooltip(
+        numericInput(ns("resp_cols"),    "Grid columns", NA, 1, 10, 1),
+        "Help: Choose how many columns of panels to use when multiple strata are plotted."
+      ))
     ),
     add_color_customization_ui(ns, multi_group = TRUE),
     hr(),
-    downloadButton(ns("download_plot"), "Download Plot", style = "width: 100%;")
+    with_help_tooltip(
+      downloadButton(ns("download_plot"), "Download Plot", style = "width: 100%;"),
+      "Help: Save the current correlation figure as an image file."
+    )
   )
 }
 

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -6,7 +6,10 @@ pca_ui <- function(id) {
   ns <- NS(id)
   list(
     config = tagList(
-      selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
+      with_help_tooltip(
+        selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
+        "Help: Pick the numeric variables whose combined patterns you want PCA to capture."
+      ),
       tags$details(
         tags$summary(strong("Advanced options")),
         helpText(paste(
@@ -16,8 +19,14 @@ pca_ui <- function(id) {
       ),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run_pca"), "Show PCA summary", width = "100%")),
-        column(6, downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"))
+        column(6, with_help_tooltip(
+          actionButton(ns("run_pca"), "Show PCA summary", width = "100%"),
+          "Help: Compute the principal components for the selected variables."
+        )),
+        column(6, with_help_tooltip(
+          downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"),
+          "Help: Export the PCA summaries, loadings, and diagnostics to a text file."
+        ))
       )
     ),
     results = tagList(

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -32,83 +32,116 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       h4("Step 4 — Visualize principal component analysis (PCA)"),
       p("Visualize multivariate structure using a PCA biplot."),
       hr(),
-      selectInput(
-        ns("plot_type"),
-        label = "Select visualization type:",
-        choices = c("PCA biplot" = "biplot"),
-        selected = "biplot"
+      with_help_tooltip(
+        selectInput(
+          ns("plot_type"),
+          label = "Select visualization type:",
+          choices = c("PCA biplot" = "biplot"),
+          selected = "biplot"
+        ),
+        "Help: Pick how the PCA results should be displayed."
       ),
       hr(),
-      selectInput(
-        ns("pca_color"),
-        label = "Color points by:",
-        choices = choices,
-        selected = "None"
+      with_help_tooltip(
+        selectInput(
+          ns("pca_color"),
+          label = "Color points by:",
+          choices = choices,
+          selected = "None"
+        ),
+        "Help: Colour the samples using a grouping variable to spot patterns."
       ),
-      selectInput(
-        ns("pca_shape"),
-        label = "Shape points by:",
-        choices = choices,
-        selected = "None"
+      with_help_tooltip(
+        selectInput(
+          ns("pca_shape"),
+          label = "Shape points by:",
+          choices = choices,
+          selected = "None"
+        ),
+        "Help: Change the point shapes using a grouping variable for extra contrast."
       ),
-      selectInput(
-        ns("pca_label"),
-        label = "Label points by:",
-        choices = choices,
-        selected = "None"
+      with_help_tooltip(
+        selectInput(
+          ns("pca_label"),
+          label = "Label points by:",
+          choices = choices,
+          selected = "None"
+        ),
+        "Help: Add text labels from a column to identify each sample."
       ),
-      selectInput(
-        ns("facet_var"),
-        label = "Facet by variable:",
-        choices = choices,
-        selected = "None"
+      with_help_tooltip(
+        selectInput(
+          ns("facet_var"),
+          label = "Facet by variable:",
+          choices = choices,
+          selected = "None"
+        ),
+        "Help: Split the plot into small multiples based on a grouping variable."
       ),
       uiOutput(ns("layout_controls")),
-      numericInput(
-        ns("pca_label_size"),
-        label = "Label size:",
-        value = 2,
-        min = 0.5,
-        max = 6,
-        step = 0.5
+      with_help_tooltip(
+        numericInput(
+          ns("pca_label_size"),
+          label = "Label size:",
+          value = 2,
+          min = 0.5,
+          max = 6,
+          step = 0.5
+        ),
+        "Help: Control how large the point labels appear on the plot."
       ),
-      checkboxInput(
-        ns("show_loadings"),
-        label = "Show loadings",
-        value = FALSE
+      with_help_tooltip(
+        checkboxInput(
+          ns("show_loadings"),
+          label = "Show loadings",
+          value = FALSE
+        ),
+        "Help: Display arrows that show how each original variable contributes to the components."
       ),
-      numericInput(
-        ns("loading_scale"),
-        label = "Loading arrow scale",
-        value = 1.2, min = 0.1, max = 5, step = 0.1
+      with_help_tooltip(
+        numericInput(
+          ns("loading_scale"),
+          label = "Loading arrow scale",
+          value = 1.2, min = 0.1, max = 5, step = 0.1
+        ),
+        "Help: Stretch or shrink the loading arrows to make them easier to read."
       ),
       fluidRow(
         column(
           width = 6,
-          numericInput(
-            ns("plot_width"),
-            label = "Plot width (px)",
-            value = 800,
-            min = 200,
-            max = 2000,
-            step = 50
+          with_help_tooltip(
+            numericInput(
+              ns("plot_width"),
+              label = "Plot width (px)",
+              value = 800,
+              min = 200,
+              max = 2000,
+              step = 50
+            ),
+            "Help: Set the width of the PCA plot in pixels."
           )
         ),
         column(
           width = 6,
-          numericInput(
-            ns("plot_height"),
-            label = "Plot height (px)",
-            value = 600,
-            min = 200,
-            max = 2000,
-            step = 50
+          with_help_tooltip(
+            numericInput(
+              ns("plot_height"),
+              label = "Plot height (px)",
+              value = 600,
+              min = 200,
+              max = 2000,
+              step = 50
+            ),
+            "Help: Set the height of the PCA plot in pixels."
           )
         )
       ),
       add_color_customization_ui(ns, multi_group = TRUE),
       hr(),
-      downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;")
+      with_help_tooltip(
+        downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
+        "Help: Save the PCA figure as an image file."
+      )
     ),
     mainPanel(
       width = 8,
@@ -228,24 +261,30 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
         fluidRow(
           column(
             width = 6,
-            numericInput(
-              ns("grid_rows"),
-              "Grid rows",
-              value = isolate(if (is.null(input$grid_rows)) NA else input$grid_rows),
-              min = 1,
-              max = 10,
-              step = 1
+            with_help_tooltip(
+              numericInput(
+                ns("grid_rows"),
+                "Grid rows",
+                value = isolate(if (is.null(input$grid_rows)) NA else input$grid_rows),
+                min = 1,
+                max = 10,
+                step = 1
+              ),
+              "Help: Decide how many rows of panels to show when faceting the PCA plot."
             )
           ),
           column(
             width = 6,
-            numericInput(
-              ns("grid_cols"),
-              "Grid columns",
-              value = isolate(if (is.null(input$grid_cols)) NA else input$grid_cols),
-              min = 1,
-              max = 10,
-              step = 1
+            with_help_tooltip(
+              numericInput(
+                ns("grid_cols"),
+                "Grid columns",
+                value = isolate(if (is.null(input$grid_cols)) NA else input$grid_cols),
+                min = 1,
+                max = 10,
+                step = 1
+              ),
+              "Help: Decide how many columns of panels to show when faceting the PCA plot."
             )
           )
         )

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -23,8 +23,14 @@ regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FA
       uiOutput(ns("formula_preview")),
       br(),
       fluidRow(
-        column(6, actionButton(ns("run"), "Show results", width = "100%")),
-        column(6, downloadButton(ns("download_model"), "Download all results", style = "width: 100%;"))
+        column(6, with_help_tooltip(
+          actionButton(ns("run"), "Show results", width = "100%"),
+          "Help: Fit the model using the chosen predictors and options."
+        )),
+        column(6, with_help_tooltip(
+          downloadButton(ns("download_model"), "Download all results", style = "width: 100%;"),
+          "Help: Export the model outputs, tables, and summaries to your computer."
+        ))
       )
     ),
     results = tagList(
@@ -47,7 +53,10 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       output$response_ui <- renderUI({
         req(data())
         types <- reg_detect_types(data())
-        selectInput(ns("dep"), "Response variable (numeric):", choices = types$num)
+        with_help_tooltip(
+          selectInput(ns("dep"), "Response variable (numeric):", choices = types$num),
+          "Help: Choose the outcome that the model should predict."
+        )
       })
 
       selected_responses <- reactive({
@@ -59,11 +68,14 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
     output$fixed_selector <- renderUI({
       req(data())
       types <- reg_detect_types(data())
-      selectInput(
-        ns("fixed"),
-        "Categorical predictors:",
-        choices = types$fac,
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("fixed"),
+          "Categorical predictors:",
+          choices = types$fac,
+          multiple = TRUE
+        ),
+        "Help: Pick factor variables that might explain differences in the response."
       )
     })
 
@@ -84,12 +96,15 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
             values <- values[!is.na(values)]
             lvls <- unique(as.character(values))
           }
-          selectInput(
-            ns(paste0("order_", var)),
-            paste("Order of levels (first = reference):", var),
-            choices = lvls,
-            selected = lvls,
-            multiple = TRUE
+          with_help_tooltip(
+            selectInput(
+              ns(paste0("order_", var)),
+              paste("Order of levels (first = reference):", var),
+              choices = lvls,
+              selected = lvls,
+              multiple = TRUE
+            ),
+            sprintf("Help: Arrange the levels of %s; the first level becomes the model reference.", var)
           )
         })
       )
@@ -98,11 +113,14 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
     output$covar_selector <- renderUI({
       req(data())
       types <- reg_detect_types(data())
-      selectInput(
-        ns("covar"),
-        "Numeric predictors:",
-        choices = types$num,
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("covar"),
+          "Numeric predictors:",
+          choices = types$num,
+          multiple = TRUE
+        ),
+        "Help: Pick numeric predictors that could help explain the response."
       )
     })
 
@@ -110,11 +128,14 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       output$random_selector <- renderUI({
         req(data())
         types <- reg_detect_types(data())
-        selectInput(
-          ns("random"),
-          "Random effect (categorical):",
-          choices = types$fac,
-          selected = NULL
+        with_help_tooltip(
+          selectInput(
+            ns("random"),
+            "Random effect (categorical):",
+            choices = types$fac,
+            selected = NULL
+          ),
+          "Help: Choose a grouping factor for random intercepts in the mixed model."
         )
       })
     }
@@ -294,7 +315,10 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
             column(6, plotOutput(ns(paste0("qq_", idx))))
           ),
           br(),
-          downloadButton(ns(paste0("download_", idx)), "Download results", style = "width: 100%;")
+          with_help_tooltip(
+            downloadButton(ns(paste0("download_", idx)), "Download results", style = "width: 100%;"),
+            "Help: Save the model summary and diagnostics for this response."
+          )
         )
       } else {
           stratum_tabs <- lapply(seq_along(strata), function(j) {
@@ -311,7 +335,10 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
                   column(6, plotOutput(ns(paste0("qq_", idx, "_", j))))
                 ),
                 br(),
-                downloadButton(ns(paste0("download_", idx, "_", j)), "Download results", style = "width: 100%;")
+                with_help_tooltip(
+                  downloadButton(ns(paste0("download_", idx, "_", j)), "Download results", style = "width: 100%;"),
+                  "Help: Save the model summary and diagnostics for this stratum."
+                )
               )
             } else {
               tags$pre(format_safe_error_message("Model fitting failed", stratum$error))

--- a/R/regression_analysis_shared.R
+++ b/R/regression_analysis_shared.R
@@ -14,13 +14,25 @@ reg_detect_types <- function(df) {
 
 reg_variable_selectors_ui <- function(ns, types, allow_random = FALSE) {
   out <- list(
-    selectInput(ns("dep"), "Response variable (numeric):", choices = types$num),
-    selectInput(ns("fixed"), "Categorical predictors:", choices = types$fac, multiple = TRUE),
-    selectInput(ns("covar"), "Numeric predictors:", choices = types$num, multiple = TRUE)
+    with_help_tooltip(
+      selectInput(ns("dep"), "Response variable (numeric):", choices = types$num),
+      "Help: Pick the numeric outcome you want the model to explain."
+    ),
+    with_help_tooltip(
+      selectInput(ns("fixed"), "Categorical predictors:", choices = types$fac, multiple = TRUE),
+      "Help: Select group variables that might influence the response."
+    ),
+    with_help_tooltip(
+      selectInput(ns("covar"), "Numeric predictors:", choices = types$num, multiple = TRUE),
+      "Help: Select numeric predictors that could explain changes in the response."
+    )
   )
   if (allow_random) {
     out <- c(out, list(
-      selectInput(ns("random"), "Random effect (categorical):", choices = types$fac, selected = NULL)
+      with_help_tooltip(
+        selectInput(ns("random"), "Random effect (categorical):", choices = types$fac, selected = NULL),
+        "Help: Choose a grouping factor for random intercepts when using mixed models."
+      )
     ))
   }
   do.call(tagList, out)
@@ -33,10 +45,13 @@ reg_interactions_ui <- function(ns, fixed, fac_vars) {
   pairs <- combn(cats_only, 2, simplify = FALSE)
   pair_labels <- vapply(pairs, function(p) paste(p, collapse = " × "), character(1))
   pair_values <- vapply(pairs, function(p) paste(p, collapse = ":"), character(1))
-  checkboxGroupInput(
-    ns("interactions"),
-    label = "Select 2-way interactions (optional):",
-    choices = stats::setNames(pair_values, pair_labels)
+  with_help_tooltip(
+    checkboxGroupInput(
+      ns("interactions"),
+      label = "Select 2-way interactions (optional):",
+      choices = stats::setNames(pair_values, pair_labels)
+    ),
+    "Help: Tick pairs of factors to let the model test if their joint effect matters."
   )
 }
 

--- a/R/submodule_multiple_responses.R
+++ b/R/submodule_multiple_responses.R
@@ -5,10 +5,13 @@
 multi_response_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    checkboxInput(
-      ns("multi_resp"),
-      "Allow multiple response variables",
-      value = FALSE
+    with_help_tooltip(
+      checkboxInput(
+        ns("multi_resp"),
+        "Allow multiple response variables",
+        value = FALSE
+      ),
+      "Help: Tick this to analyse several response variables one after another."
     ),
     uiOutput(ns("response_ui"))
   )
@@ -30,15 +33,18 @@ multi_response_server <- function(id, data) {
       num_vars <- names(d)[sapply(d, is.numeric)]
       validate(need(length(num_vars) > 0, "No numeric variables available."))
       
-      selectInput(
-        ns("response"),
-        label = if (isTRUE(input$multi_resp))
-          "Response variables (numeric):"
-        else
-          "Response variable (numeric):",
-        choices = num_vars,
-        selected = num_vars[1],
-        multiple = isTRUE(input$multi_resp)
+      with_help_tooltip(
+        selectInput(
+          ns("response"),
+          label = if (isTRUE(input$multi_resp))
+            "Response variables (numeric):"
+          else
+            "Response variable (numeric):",
+          choices = num_vars,
+          selected = num_vars[1],
+          multiple = isTRUE(input$multi_resp)
+        ),
+        "Help: Choose the numeric outcomes the model should process."
       )
     })
     

--- a/R/submodule_stratification.R
+++ b/R/submodule_stratification.R
@@ -34,11 +34,14 @@ stratification_server <- function(id, data) {
     output$stratify_var_ui <- renderUI({
       d <- req(df())
       cat_cols <- names(d)[vapply(d, function(x) is.factor(x) || is.character(x), logical(1))]
-      selectInput(
-        ns("stratify_var"),
-        "Stratify by:",
-        choices = c("None", cat_cols),
-        selected = "None"
+      with_help_tooltip(
+        selectInput(
+          ns("stratify_var"),
+          "Stratify by:",
+          choices = c("None", cat_cols),
+          selected = "None"
+        ),
+        "Help: Pick a categorical variable if you want separate summaries for each group."
       )
     })
     
@@ -58,12 +61,15 @@ stratification_server <- function(id, data) {
                     sprintf("'%s' has too many levels (%d > %d).",
                             input$stratify_var, n_levels, MAX_STRATIFICATION_LEVELS)))
       
-      selectInput(
-        ns("strata_order"),
-        "Order of levels:",
-        choices = available_levels,
-        selected = available_levels,
-        multiple = TRUE
+      with_help_tooltip(
+        selectInput(
+          ns("strata_order"),
+          "Order of levels:",
+          choices = available_levels,
+          selected = available_levels,
+          multiple = TRUE
+        ),
+        "Help: Decide which group levels to include and in what order they should appear."
       )
     })
     

--- a/app.R
+++ b/app.R
@@ -49,6 +49,7 @@ ui <- navbarPage(
       .empty-state { max-width: 420px; margin-left: auto; margin-right: auto; }
       .empty-state-icon { font-size: 3rem; line-height: 1; }
       .empty-state h4 { font-weight: 600; }
+      .ta-help-tooltip { cursor: help; display: inline-block; width: 100%; }
     "))
   ),
   


### PR DESCRIPTION
## Summary
- add a shared tooltip wrapper so every Shiny widget exposes plain-language help text
- annotate upload, filter, analysis, and visualization controls with consistent "Help:" guidance for novice users
- style tooltip wrappers to show a help cursor and integrate with existing colour-picking utilities

## Testing
- Rscript -e "testthat::test_dir('tests')" *(fails: Rscript command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc6bcf9fc832b9402cb2701d16e5c)