### PR TITLE
Remove trailing colons from widget labels

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -54,7 +54,7 @@ one_way_anova_server <- function(id, filtered_data) {
         with_help_tooltip(
           selectInput(
             ns("group"),
-            "Categorical predictor:",
+            "Categorical predictor",
             choices = cat_cols,
             selected = if (length(cat_cols) > 0) cat_cols[1] else NULL
           ),
@@ -74,7 +74,7 @@ one_way_anova_server <- function(id, filtered_data) {
       with_help_tooltip(
         selectInput(
           ns("order"),
-          "Order of levels (first = reference):",
+          "Order of levels (first = reference)",
           choices = levels,
           selected = levels,
           multiple = TRUE

--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -13,7 +13,7 @@ visualize_oneway_ui <- function(id) {
       with_help_tooltip(
         selectInput(
           ns("plot_type"),
-          label = "Select visualization type:",
+          label = "Select visualization type",
           choices = c(
             "Lineplots (mean ± SE)" = "lineplot_mean_se",
             "Barplots (mean ± SE)"  = "barplot_mean_se"

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -55,7 +55,7 @@ two_way_anova_server <- function(id, filtered_data) {
         with_help_tooltip(
           selectInput(
             ns("factor1"),
-            "Categorical predictor 1 (x-axis):",
+            "Categorical predictor 1 (x-axis)",
             choices = cat_cols,
             selected = if (length(cat_cols) > 0) cat_cols[1] else NULL
           ),
@@ -64,7 +64,7 @@ two_way_anova_server <- function(id, filtered_data) {
         with_help_tooltip(
           selectInput(
             ns("factor2"),
-            "Categorical predictor 2 (lines):",
+            "Categorical predictor 2 (lines)",
             choices = cat_cols,
             selected = if (length(cat_cols) > 1) cat_cols[2] else NULL
           ),
@@ -84,7 +84,7 @@ two_way_anova_server <- function(id, filtered_data) {
       with_help_tooltip(
         selectInput(
           ns("order1"),
-          paste("Order of levels (first = reference):", input$factor1, "(x-axis)"),
+          paste("Order of levels (first = reference)", input$factor1, "(x-axis)"),
           choices = levels1,
           selected = levels1,
           multiple = TRUE
@@ -99,7 +99,7 @@ two_way_anova_server <- function(id, filtered_data) {
       with_help_tooltip(
         selectInput(
           ns("order2"),
-          paste("Order of levels (first = reference):", input$factor2, "(lines)"),
+          paste("Order of levels (first = reference)", input$factor2, "(lines)"),
           choices = levels2,
           selected = levels2,
           multiple = TRUE

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -13,7 +13,7 @@ visualize_twoway_ui <- function(id) {
       with_help_tooltip(
         selectInput(
           ns("plot_type"),
-          label = "Select visualization type:",
+          label = "Select visualization type",
           choices = c(
             "Lineplots (mean ± SE)" = "lineplot_mean_se",
             "Barplots (mean ± SE)"  = "barplot_mean_se"

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -46,11 +46,11 @@ descriptive_server <- function(id, filtered_data) {
       
       tagList(
         with_help_tooltip(
-          selectInput(ns("cat_vars"), label = "Categorical variables:", choices = cat_cols, selected = cat_cols, multiple = TRUE),
+          selectInput(ns("cat_vars"), label = "Categorical variables", choices = cat_cols, selected = cat_cols, multiple = TRUE),
           "Help: Choose the group variables whose counts and proportions you want to inspect."
         ),
         with_help_tooltip(
-          selectInput(ns("num_vars"), label = "Numeric variables:", choices = num_cols, selected = num_cols, multiple = TRUE),
+          selectInput(ns("num_vars"), label = "Numeric variables", choices = num_cols, selected = num_cols, multiple = TRUE),
           "Help: Choose the numeric measurements you want to summarise (mean, SD, etc.)."
         )
       )

--- a/R/descriptive_visualize.R
+++ b/R/descriptive_visualize.R
@@ -13,7 +13,7 @@ visualize_descriptive_ui <- function(id) {
       with_help_tooltip(
         selectInput(
           ns("plot_type"),
-          label = "Select visualization type:",
+          label = "Select visualization type",
           choices = c(
             "Categorical barplots" = "categorical",
             "Numeric boxplots"          = "boxplots",

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -150,7 +150,7 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       with_help_tooltip(
         selectInput(
           ns("outlier_label"),
-          label = "Label outliers by:",
+          label = "Label outliers by",
           choices = c("None" = "", stats::setNames(cat_cols, cat_cols)),
           selected = current
         ),

--- a/R/module_analysis.R
+++ b/R/module_analysis.R
@@ -23,7 +23,7 @@ analysis_ui <- function(id) {
       with_help_tooltip(
         selectInput(
           ns("analysis_type"),
-          "Select analysis type:",
+          "Select analysis type",
           choices = list(
             " " = "",
             "Descriptive" = c("Descriptive Statistics" = "Descriptive Statistics"),

--- a/R/module_filter.R
+++ b/R/module_filter.R
@@ -32,7 +32,7 @@ filter_server <- function(id, uploaded_data) {
       with_help_tooltip(
         selectInput(
           ns("columns"),
-          "Select columns to filter:",
+          "Select columns to filter",
           choices = names(df()),
           multiple = TRUE
         ),

--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -13,7 +13,7 @@ upload_ui <- function(id) {
       with_help_tooltip(
         radioButtons(
           ns("data_source"),
-          label = "Data source:",
+          label = "Data source",
           choices = c(
             "Example dataset" = "example",
             "Upload (long format)" = "long",
@@ -126,7 +126,7 @@ upload_server <- function(id) {
       output$validation_msg <- renderText(paste("✅ File loaded:", input$file$name))
       output$sheet_selector <- renderUI(
         with_help_tooltip(
-          selectInput(ns("sheet"), "Select sheet:", choices = sheets),
+          selectInput(ns("sheet"), "Select sheet", choices = sheets),
           "Help: Pick the worksheet inside your Excel file that contains the data."
         )
       )

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -7,7 +7,7 @@ ggpairs_ui <- function(id) {
   list(
     config = tagList(
       with_help_tooltip(
-        selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
+        selectInput(ns("vars"), "Numeric variables", choices = NULL, multiple = TRUE),
         "Help: Choose which numeric columns to include in the correlation matrix."
       ),
       tags$details(

--- a/R/pairwise_correlation_visualize.R
+++ b/R/pairwise_correlation_visualize.R
@@ -13,7 +13,7 @@ visualize_ggpairs_ui <- function(id) {
       with_help_tooltip(
         selectInput(
           ns("plot_type"),
-          label = "Select visualization type:",
+          label = "Select visualization type",
           choices = c("Pairwise scatterplot matrix" = "GGPairs"),
           selected = "GGPairs"
         ),

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -7,7 +7,7 @@ pca_ui <- function(id) {
   list(
     config = tagList(
       with_help_tooltip(
-        selectInput(ns("vars"), "Numeric variables:", choices = NULL, multiple = TRUE),
+        selectInput(ns("vars"), "Numeric variables", choices = NULL, multiple = TRUE),
         "Help: Pick the numeric variables whose combined patterns you want PCA to capture."
       ),
       tags$details(

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -35,7 +35,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       with_help_tooltip(
         selectInput(
           ns("plot_type"),
-          label = "Select visualization type:",
+          label = "Select visualization type",
           choices = c("PCA biplot" = "biplot"),
           selected = "biplot"
         ),
@@ -44,7 +44,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       with_help_tooltip(
         selectInput(
           ns("pca_color"),
-          label = "Color points by:",
+          label = "Color points by",
           choices = choices,
           selected = "None"
         ),
@@ -53,7 +53,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       with_help_tooltip(
         selectInput(
           ns("pca_shape"),
-          label = "Shape points by:",
+          label = "Shape points by",
           choices = choices,
           selected = "None"
         ),
@@ -62,7 +62,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       with_help_tooltip(
         selectInput(
           ns("pca_label"),
-          label = "Label points by:",
+          label = "Label points by",
           choices = choices,
           selected = "None"
         ),
@@ -71,7 +71,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       with_help_tooltip(
         selectInput(
           ns("facet_var"),
-          label = "Facet by variable:",
+          label = "Facet by variable",
           choices = choices,
           selected = "None"
         ),
@@ -81,7 +81,7 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
       with_help_tooltip(
         numericInput(
           ns("pca_label_size"),
-          label = "Label size:",
+          label = "Label size",
           value = 2,
           min = 0.5,
           max = 6,

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -54,7 +54,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         req(data())
         types <- reg_detect_types(data())
         with_help_tooltip(
-          selectInput(ns("dep"), "Response variable (numeric):", choices = types$num),
+          selectInput(ns("dep"), "Response variable (numeric)", choices = types$num),
           "Help: Choose the outcome that the model should predict."
         )
       })
@@ -71,7 +71,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       with_help_tooltip(
         selectInput(
           ns("fixed"),
-          "Categorical predictors:",
+          "Categorical predictors",
           choices = types$fac,
           multiple = TRUE
         ),
@@ -99,7 +99,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
           with_help_tooltip(
             selectInput(
               ns(paste0("order_", var)),
-              paste("Order of levels (first = reference):", var),
+              paste("Order of levels (first = reference)", var),
               choices = lvls,
               selected = lvls,
               multiple = TRUE
@@ -116,7 +116,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       with_help_tooltip(
         selectInput(
           ns("covar"),
-          "Numeric predictors:",
+          "Numeric predictors",
           choices = types$num,
           multiple = TRUE
         ),
@@ -131,7 +131,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         with_help_tooltip(
           selectInput(
             ns("random"),
-            "Random effect (categorical):",
+            "Random effect (categorical)",
             choices = types$fac,
             selected = NULL
           ),

--- a/R/regression_analysis_shared.R
+++ b/R/regression_analysis_shared.R
@@ -15,22 +15,22 @@ reg_detect_types <- function(df) {
 reg_variable_selectors_ui <- function(ns, types, allow_random = FALSE) {
   out <- list(
     with_help_tooltip(
-      selectInput(ns("dep"), "Response variable (numeric):", choices = types$num),
+      selectInput(ns("dep"), "Response variable (numeric)", choices = types$num),
       "Help: Pick the numeric outcome you want the model to explain."
     ),
     with_help_tooltip(
-      selectInput(ns("fixed"), "Categorical predictors:", choices = types$fac, multiple = TRUE),
+      selectInput(ns("fixed"), "Categorical predictors", choices = types$fac, multiple = TRUE),
       "Help: Select group variables that might influence the response."
     ),
     with_help_tooltip(
-      selectInput(ns("covar"), "Numeric predictors:", choices = types$num, multiple = TRUE),
+      selectInput(ns("covar"), "Numeric predictors", choices = types$num, multiple = TRUE),
       "Help: Select numeric predictors that could explain changes in the response."
     )
   )
   if (allow_random) {
     out <- c(out, list(
       with_help_tooltip(
-        selectInput(ns("random"), "Random effect (categorical):", choices = types$fac, selected = NULL),
+        selectInput(ns("random"), "Random effect (categorical)", choices = types$fac, selected = NULL),
         "Help: Choose a grouping factor for random intercepts when using mixed models."
       )
     ))
@@ -48,7 +48,7 @@ reg_interactions_ui <- function(ns, fixed, fac_vars) {
   with_help_tooltip(
     checkboxGroupInput(
       ns("interactions"),
-      label = "Select 2-way interactions (optional):",
+      label = "Select 2-way interactions (optional)",
       choices = stats::setNames(pair_values, pair_labels)
     ),
     "Help: Tick pairs of factors to let the model test if their joint effect matters."

--- a/R/submodule_multiple_responses.R
+++ b/R/submodule_multiple_responses.R
@@ -37,9 +37,9 @@ multi_response_server <- function(id, data) {
         selectInput(
           ns("response"),
           label = if (isTRUE(input$multi_resp))
-            "Response variables (numeric):"
+            "Response variables (numeric)"
           else
-            "Response variable (numeric):",
+            "Response variable (numeric)",
           choices = num_vars,
           selected = num_vars[1],
           multiple = isTRUE(input$multi_resp)

--- a/R/submodule_stratification.R
+++ b/R/submodule_stratification.R
@@ -37,7 +37,7 @@ stratification_server <- function(id, data) {
       with_help_tooltip(
         selectInput(
           ns("stratify_var"),
-          "Stratify by:",
+          "Stratify by",
           choices = c("None", cat_cols),
           selected = "None"
         ),
@@ -64,7 +64,7 @@ stratification_server <- function(id, data) {
       with_help_tooltip(
         selectInput(
           ns("strata_order"),
-          "Order of levels:",
+          "Order of levels",
           choices = available_levels,
           selected = available_levels,
           multiple = TRUE


### PR DESCRIPTION
## Summary
- remove trailing colons from Shiny widget labels across upload, filter, analysis, and visualization modules to improve UI consistency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106bcb1034832ba94f8eec6893d287)