### PR TITLE
Refactor home tab into Shiny module

### DIFF
--- a/R/module_home.R
+++ b/R/module_home.R
@@ -1,0 +1,73 @@
+# ===============================================================
+# 🏠 Table Analyzer — Home Module
+# ===============================================================
+
+home_ui <- function(id) {
+  ns <- NS(id)
+
+  fluidPage(
+    div(
+      class = "home-wrapper px-3",
+      div(
+        class = "hero text-center mx-auto",
+        h1("Welcome to Table Analyzer"),
+        p(
+          class = "lead text-muted",
+          "Turn your tabular data into publication-ready tables and plots in a single afternoon."
+        ),
+        br(),
+        div(
+          class = "home-steps",
+          fluidRow(
+            class = "g-4 justify-content-center",
+            column(
+              width = 3,
+              div(
+                icon("upload", class = "fa-2x text-primary mb-2"),
+                h5("1. Upload"),
+                p("Bring in spreadsheets with ease.")
+              )
+            ),
+            column(
+              width = 3,
+              div(
+                icon("filter", class = "fa-2x text-primary mb-2"),
+                h5("2. Filter"),
+                p("Refine rows and columns to spotlight what's important.")
+              )
+            ),
+            column(
+              width = 3,
+              div(
+                icon("chart-line", class = "fa-2x text-primary mb-2"),
+                h5("3. Analyze"),
+                p("Run summaries and models tailored to your dataset.")
+              )
+            ),
+            column(
+              width = 3,
+              div(
+                icon("chart-area", class = "fa-2x text-primary mb-2"),
+                h5("4. Visualize"),
+                p("Create polished plots to communicate key findings.")
+              )
+            )
+          )
+        ),
+        br(),
+        tags$hr(class = "my-4"),
+        p(
+          em("Developed by Nicola Palmieri"),
+          class = "text-muted small"
+        )
+      )
+    )
+  )
+}
+
+
+home_server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    # Placeholder for future home page interactivity
+  })
+}

--- a/app.R
+++ b/app.R
@@ -75,64 +75,7 @@ ui <- navbarPage(
 
   tabPanel(
     title = tagList(icon("home"), " Home"),
-    fluidPage(
-      div(
-        class = "home-wrapper px-3",
-        div(
-          class = "hero text-center mx-auto",
-          h1("Welcome to Table Analyzer"),
-          p(
-            class = "lead text-muted",
-            "Turn your tabular data into publication-ready tables and plots in a single afternoon."
-          ),
-          br(),
-          div(
-            class = "home-steps",
-            fluidRow(
-              class = "g-4 justify-content-center",
-              column(
-                width = 3,
-                div(
-                  icon("upload", class = "fa-2x text-primary mb-2"),
-                  h5("1. Upload"),
-                  p("Bring in spreadsheets with ease.")
-                )
-              ),
-              column(
-                width = 3,
-                div(
-                  icon("filter", class = "fa-2x text-primary mb-2"),
-                  h5("2. Filter"),
-                  p("Refine rows and columns to spotlight what's important.")
-                )
-              ),
-              column(
-                width = 3,
-                div(
-                  icon("chart-line", class = "fa-2x text-primary mb-2"),
-                  h5("3. Analyze"),
-                  p("Run summaries and models tailored to your dataset.")
-                )
-              ),
-              column(
-                width = 3,
-                div(
-                  icon("chart-area", class = "fa-2x text-primary mb-2"),
-                  h5("4. Visualize"),
-                  p("Create polished plots to communicate key findings.")
-                )
-              )
-            )
-          ),
-          br(),
-          tags$hr(class = "my-4"),
-          p(
-            em("Developed by Nicola Palmieri"),
-            class = "text-muted small"
-          )
-        )
-      )
-    )
+    home_ui("home")
   ),
 
   tabPanel(
@@ -157,6 +100,7 @@ ui <- navbarPage(
 # SERVER
 # ---------------------------------------------------------------
 server <- function(input, output, session) {
+  home_server("home")
   uploaded  <- upload_server("upload")
   filtered  <- filter_server("filter", uploaded)
   analyzed  <- analysis_server("analysis", filtered)


### PR DESCRIPTION
## Summary
- extract the existing Home tab layout into a dedicated `home_ui` module for reuse
- register a placeholder `home_server` module and wire it into the main app

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691081f05628832bb597ff1fd6d24edd)