### PR TITLE
Add base size controls alongside color customization

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -44,7 +44,14 @@ visualize_oneway_ui <- function(id) {
           "Adjust how tall each subplot should be in pixels."
         ))
       ),
-      add_color_customization_ui(ns, multi_group = FALSE),
+      fluidRow(
+        column(6, add_color_customization_ui(ns, multi_group = FALSE)),
+        column(6, base_size_ui(
+          ns,
+          default = 14,
+          help_text = "Adjust the base font size used for the ANOVA plots."
+        ))
+      ),
       br(),
       with_help_tooltip(
         downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -76,6 +83,11 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       multi_group = FALSE
     )
 
+    base_size <- base_size_server(
+      input = input,
+      default = 14
+    )
+
     last_plot_type <- reactiveVal("lineplot_mean_se")
 
     observeEvent(input$plot_type, {
@@ -93,7 +105,7 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       )
     }
 
-    compute_all_plots <- function(data, info, layout_inputs, colors) {
+    compute_all_plots <- function(data, info, layout_inputs, colors, base_size_value) {
       if (is.null(info)) {
         return(list())
       }
@@ -133,7 +145,8 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
           data,
           info,
           layout_inputs,
-          line_colors = colors
+          line_colors = colors,
+          base_size = base_size_value
         )
       )
 
@@ -149,7 +162,8 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
           layout_values = layout_inputs,
           line_colors = colors,
           posthoc_all = posthoc_data,
-          show_value_labels = isTRUE(input$show_bar_labels)
+          show_value_labels = isTRUE(input$show_bar_labels),
+          base_size = base_size_value
         )
       )
 
@@ -165,6 +179,7 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
         input$resp_rows,
         input$resp_cols,
         custom_colors(),
+        base_size(),
         input$show_bar_labels
       ),
       {
@@ -177,7 +192,13 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
           resp_cols = input$resp_cols
         )
 
-        cached_results$plots <- compute_all_plots(data, info, layout_inputs, custom_colors())
+        cached_results$plots <- compute_all_plots(
+          data,
+          info,
+          layout_inputs,
+          custom_colors(),
+          base_size()
+        )
       },
       ignoreNULL = FALSE
     )

--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -989,7 +989,13 @@ finalize_anova_plot_result <- function(response_plots,
   )
 }
 
-build_line_plot_panel <- function(stats_df, title_text, y_limits, factor1, factor2, line_colors) {
+build_line_plot_panel <- function(stats_df,
+                                  title_text,
+                                  y_limits,
+                                  factor1,
+                                  factor2,
+                                  line_colors,
+                                  base_size = 14) {
   if (is.null(factor2) || !factor2 %in% names(stats_df)) {
     color_value <- if (!is.null(line_colors) && length(line_colors) > 0) {
       unname(line_colors)[1]
@@ -1004,7 +1010,7 @@ build_line_plot_panel <- function(stats_df, title_text, y_limits, factor1, facto
         width = 0.15,
         color = color_value
       ) +
-      theme_minimal(base_size = 14) +
+      theme_minimal(base_size = base_size) +
       labs(x = factor1, y = "Mean ± SE") +
       theme(
         panel.grid.minor = element_blank(),
@@ -1031,7 +1037,7 @@ build_line_plot_panel <- function(stats_df, title_text, y_limits, factor1, facto
         aes(ymin = mean - se, ymax = mean + se),
         width = 0.15
       ) +
-      theme_minimal(base_size = 14) +
+      theme_minimal(base_size = base_size) +
       labs(
         x = factor1,
         y = "Mean ± SE",
@@ -1052,7 +1058,11 @@ build_line_plot_panel <- function(stats_df, title_text, y_limits, factor1, facto
     theme(plot.title = element_text(size = 12, face = "bold"))
 }
 
-plot_anova_lineplot_meanse <- function(data, info, layout_values, line_colors = NULL) {
+plot_anova_lineplot_meanse <- function(data,
+                                       info,
+                                       layout_values,
+                                       line_colors = NULL,
+                                       base_size = 14) {
   context <- initialize_anova_plot_context(data, info, layout_values)
   data <- context$data
   factor1 <- context$factor1
@@ -1101,7 +1111,8 @@ plot_anova_lineplot_meanse <- function(data, info, layout_values, line_colors = 
           y_limits = y_limits,
           factor1 = factor1,
           factor2 = factor2,
-          line_colors = line_colors
+          line_colors = line_colors,
+          base_size = base_size
         )
       })
 
@@ -1141,7 +1152,8 @@ plot_anova_lineplot_meanse <- function(data, info, layout_values, line_colors = 
         y_limits = y_limits,
         factor1 = factor1,
         factor2 = factor2,
-        line_colors = line_colors
+        line_colors = line_colors,
+        base_size = base_size
       )
     }
   }
@@ -1161,7 +1173,8 @@ build_bar_plot_panel <- function(stats_df,
                                  line_colors,
                                  base_fill,
                                  signif_df = NULL,
-                                 show_value_labels = FALSE) {
+                                 show_value_labels = FALSE,
+                                 base_size = 14) {
   format_numeric_labels <- scales::label_number(accuracy = 0.01, trim = TRUE)
 
   if (is.null(factor2) || !factor2 %in% names(stats_df)) {
@@ -1173,7 +1186,7 @@ build_bar_plot_panel <- function(stats_df,
         color = "gray40",
         linewidth = 0.5
       ) +
-      theme_minimal(base_size = 14) +
+      theme_minimal(base_size = base_size) +
       labs(
         x = factor1,
         y = "Mean ± SE",
@@ -1282,7 +1295,7 @@ build_bar_plot_panel <- function(stats_df,
       color = "gray40",
       linewidth = 0.5
     ) +
-    theme_minimal(base_size = 14) +
+    theme_minimal(base_size = base_size) +
     labs(
       x = factor1,
       y = "Mean ± SE",
@@ -1532,7 +1545,8 @@ plot_anova_barplot_meanse <- function(data,
                                       layout_values = list(),
                                       line_colors = NULL,
                                       posthoc_all = NULL,
-                                      show_value_labels = FALSE) {
+                                      show_value_labels = FALSE,
+                                      base_size = 14) {
   context <- initialize_anova_plot_context(data, info, layout_values)
   data <- context$data
   factor1 <- context$factor1
@@ -1587,7 +1601,8 @@ plot_anova_barplot_meanse <- function(data,
           line_colors = line_colors,
           base_fill = base_fill,
           signif_df = signif_df,
-          show_value_labels = show_value_labels
+          show_value_labels = show_value_labels,
+          base_size = base_size
         )
       }
 
@@ -1628,7 +1643,8 @@ plot_anova_barplot_meanse <- function(data,
         line_colors = line_colors,
         base_fill = base_fill,
         signif_df = signif_df,
-        show_value_labels = show_value_labels
+        show_value_labels = show_value_labels,
+        base_size = base_size
       )
     }
   }

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -44,7 +44,14 @@ visualize_twoway_ui <- function(id) {
           "Set how tall each subplot should be in pixels."
         ))
       ),
-      add_color_customization_ui(ns, multi_group = TRUE),
+      fluidRow(
+        column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+        column(6, base_size_ui(
+          ns,
+          default = 14,
+          help_text = "Adjust the base font size used for the ANOVA plots."
+        ))
+      ),
       br(),
       with_help_tooltip(
         downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -82,6 +89,11 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       multi_group = TRUE
     )
 
+    base_size <- base_size_server(
+      input = input,
+      default = 14
+    )
+
     last_plot_type <- reactiveVal("lineplot_mean_se")
     
     observeEvent(input$plot_type, {
@@ -99,7 +111,7 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       )
     }
 
-    compute_all_plots <- function(data, info, layout_inputs, colors) {
+    compute_all_plots <- function(data, info, layout_inputs, colors, base_size_value) {
       if (is.null(info)) {
         return(list())
       }
@@ -145,7 +157,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
           data,
           info,
           layout_inputs,
-          line_colors = line_colors
+          line_colors = line_colors,
+          base_size = base_size_value
         )
       )
 
@@ -161,7 +174,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
           layout_values = layout_inputs,
           line_colors = line_colors,
           posthoc_all = posthoc_data,
-          show_value_labels = isTRUE(input$show_bar_labels)
+          show_value_labels = isTRUE(input$show_bar_labels),
+          base_size = base_size_value
         )
       )
 
@@ -177,6 +191,7 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
         input$resp_rows,
         input$resp_cols,
         custom_colors(),
+        base_size(),
         input$show_bar_labels
       ),
       {
@@ -189,7 +204,13 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
           resp_cols = input$resp_cols
         )
 
-        cached_results$plots <- compute_all_plots(data, info, layout_inputs, custom_colors())
+        cached_results$plots <- compute_all_plots(
+          data,
+          info,
+          layout_inputs,
+          custom_colors(),
+          base_size()
+        )
       },
       ignoreNULL = FALSE
     )

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -53,7 +53,14 @@ visualize_categorical_barplots_ui <- function(id) {
         )
       )
     ),
-    add_color_customization_ui(ns, multi_group = TRUE),
+    fluidRow(
+      column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+      column(6, base_size_ui(
+        ns,
+        default = 13,
+        help_text = "Adjust the base font size used for barplot text elements."
+      ))
+    ),
     hr(),
     with_help_tooltip(
       downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -124,6 +131,11 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       multi_group = TRUE
     )
 
+    base_size <- base_size_server(
+      input = input,
+      default = 13
+    )
+
     cached_plot_info <- reactiveVal(NULL)
     cache_ready <- reactiveVal(FALSE)
 
@@ -139,7 +151,8 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         filtered_data(),
         input$show_proportions,
         input$show_value_labels,
-        custom_colors()
+        custom_colors(),
+        base_size()
       ),
       {
         invalidate_cache()
@@ -184,7 +197,8 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         nrow_input = input$resp_rows,
         ncol_input = input$resp_cols,
         fill_colors = custom_colors(),
-        show_value_labels = isTRUE(input$show_value_labels)
+        show_value_labels = isTRUE(input$show_value_labels),
+        base_size = base_size()
       )
       validate(need(!is.null(out), "No categorical variables available for plotting."))
       out
@@ -283,7 +297,8 @@ build_descriptive_categorical_plot <- function(df,
                                                nrow_input = NULL,
                                                ncol_input = NULL,
                                                fill_colors = NULL,
-                                               show_value_labels = FALSE) {
+                                               show_value_labels = FALSE,
+                                               base_size = 13) {
   if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) return(NULL)
   
   factor_vars <- names(df)[vapply(df, function(x) {
@@ -357,7 +372,7 @@ build_descriptive_categorical_plot <- function(df,
       p <- ggplot(count_df, aes(x = .data[[var]], y = .data$value, fill = .data[[group_col]])) +
         geom_col(position = group_dodge, width = 0.65) +
         scale_fill_manual(values = palette) +
-        theme_minimal(base_size = 13) +
+        theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label, fill = group_col) +
         theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
@@ -428,7 +443,7 @@ build_descriptive_categorical_plot <- function(df,
 
       p <- ggplot(count_df, aes(x = .data[[var]], y = .data$value)) +
         geom_col(fill = single_fill, width = 0.65) +
-        theme_minimal(base_size = 13) +
+        theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label) +
         theme(axis.text.x = element_text(angle = 45, hjust = 1))
 

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -17,7 +17,14 @@ metric_panel_ui <- function(id, default_width = 400, default_height = 300,
         "Set the height of each metric panel in pixels."
       ))
     ),
-    add_color_customization_ui(ns, multi_group = TRUE),
+    fluidRow(
+      column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+      column(6, base_size_ui(
+        ns,
+        default = 13,
+        help_text = "Adjust the base font size used for metric plot text elements."
+      ))
+    ),
     hr(),
     with_help_tooltip(
       downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -184,7 +191,11 @@ tidy_descriptive_metric <- function(df, prefix) {
 }
 
 
-build_metric_plot <- function(metric_info, y_label, title, custom_colors = NULL) {
+build_metric_plot <- function(metric_info,
+                              y_label,
+                              title,
+                              custom_colors = NULL,
+                              base_size = 13) {
   df <- metric_info$data
   has_group <- isTRUE(metric_info$has_group)
 
@@ -202,7 +213,7 @@ build_metric_plot <- function(metric_info, y_label, title, custom_colors = NULL)
   }
   
   p +
-    theme_minimal(base_size = 13) +
+    theme_minimal(base_size = base_size) +
     labs(x = NULL, y = y_label, title = title) +
     theme(
       axis.text.x = element_text(angle = 45, hjust = 1),
@@ -260,6 +271,11 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       multi_group = TRUE
     )
 
+    base_size <- base_size_server(
+      input = input,
+      default = 13
+    )
+
     cached_plot_details <- reactiveVal(NULL)
     cache_ready <- reactiveVal(FALSE)
 
@@ -272,7 +288,8 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       list(
         summary_info(),
         filtered_data(),
-        custom_colors()
+        custom_colors(),
+        base_size()
       ),
       {
         invalidate_cache()
@@ -316,7 +333,13 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       }
 
       list(
-        plot = build_metric_plot(metric_info, y_label, title, custom_colors = custom_colors())
+        plot = build_metric_plot(
+          metric_info,
+          y_label,
+          title,
+          custom_colors = custom_colors(),
+          base_size = base_size()
+        )
       )
     }
 

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -57,7 +57,14 @@ visualize_numeric_boxplots_ui <- function(id) {
         )
       )
     ),
-    add_color_customization_ui(ns, multi_group = TRUE),
+    fluidRow(
+      column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+      column(6, base_size_ui(
+        ns,
+        default = 13,
+        help_text = "Adjust the base font size used for boxplot text elements."
+      ))
+    ),
     hr(),
     with_help_tooltip(
       downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -130,6 +137,11 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       multi_group = TRUE
     )
 
+    base_size <- base_size_server(
+      input = input,
+      default = 13
+    )
+
     output$outlier_label_ui <- renderUI({
       dat <- filtered_data()
       cat_cols <- character(0)
@@ -174,7 +186,8 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         input$show_points,
         input$show_outliers,
         input$outlier_label,
-        custom_colors()
+        custom_colors(),
+        base_size()
       ),
       {
         invalidate_cache()
@@ -218,7 +231,8 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         outlier_label_var = validate_outlier_label(input$outlier_label),
         nrow_input = input$resp_rows,
         ncol_input = input$resp_cols,
-        custom_colors = custom_colors()
+        custom_colors = custom_colors(),
+        base_size = base_size()
       )
 
       validate(need(!is.null(out), "No numeric variables available for plotting."))
@@ -318,7 +332,8 @@ build_descriptive_numeric_boxplot <- function(df,
                                               outlier_label_var = NULL,
                                               nrow_input = NULL,
                                               ncol_input = NULL,
-                                              custom_colors = NULL) {
+                                              custom_colors = NULL,
+                                              base_size = 13) {
   if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) return(NULL)
 
   num_vars <- names(df)[vapply(df, is.numeric, logical(1))]
@@ -345,7 +360,7 @@ build_descriptive_numeric_boxplot <- function(df,
       p <- ggplot(df, aes(x = .data[[group_var]], y = .data[[var]], fill = .data[[group_var]])) +
         geom_boxplot(outlier.shape = NA, width = 0.6) +
         scale_fill_manual(values = palette) +
-        theme_minimal(base_size = 13) +
+        theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = var) +
         theme(axis.text.x = element_text(angle = 45, hjust = 1))
       added_color_scale <- FALSE
@@ -395,7 +410,7 @@ build_descriptive_numeric_boxplot <- function(df,
       # ✅ always provide an x aesthetic
       p <- ggplot(df, aes(x = factor(1), y = .data[[var]])) +
         geom_boxplot(fill = resolve_single_color(custom_colors), width = 0.3) +
-        theme_minimal(base_size = 13) +
+        theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = var) +
         theme(axis.text.x = element_blank(), axis.ticks.x = element_blank())
       if (isTRUE(show_points)) {

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -29,7 +29,14 @@ visualize_numeric_histograms_ui <- function(id) {
         "Choose how many columns of histograms to display when several charts are shown."
       ))
     ),
-    add_color_customization_ui(ns, multi_group = TRUE),
+    fluidRow(
+      column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+      column(6, base_size_ui(
+        ns,
+        default = 13,
+        help_text = "Adjust the base font size used for histogram text elements."
+      ))
+    ),
     hr(),
     with_help_tooltip(
       downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -102,6 +109,11 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       multi_group = TRUE
     )
 
+    base_size <- base_size_server(
+      input = input,
+      default = 13
+    )
+
     cached_plot_info <- reactiveVal(NULL)
     cache_ready <- reactiveVal(FALSE)
 
@@ -116,7 +128,8 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
         summary_info(),
         filtered_data(),
         input$use_density,
-        custom_colors()
+        custom_colors(),
+        base_size()
       ),
       {
         invalidate_cache()
@@ -158,7 +171,8 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
         use_density = isTRUE(input$use_density),
         nrow_input = input$resp_rows,
         ncol_input = input$resp_cols,
-        custom_colors = custom_colors()
+        custom_colors = custom_colors(),
+        base_size = base_size()
       )
       validate(need(!is.null(out), "No numeric variables available for plotting."))
       out
@@ -256,7 +270,8 @@ build_descriptive_numeric_histogram <- function(df,
                                                 use_density = FALSE,
                                                 nrow_input = NULL,
                                                 ncol_input = NULL,
-                                                custom_colors = NULL) {
+                                                custom_colors = NULL,
+                                                base_size = 13) {
   if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) return(NULL)
   
   num_vars <- names(df)[vapply(df, is.numeric, logical(1))]
@@ -330,7 +345,7 @@ build_descriptive_numeric_histogram <- function(df,
     }
     
     p +
-      theme_minimal(base_size = 13) +
+      theme_minimal(base_size = base_size) +
       labs(title = var, x = var, y = y_label)
   })
   

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -25,7 +25,14 @@ pairwise_correlation_visualize_ggpairs_ui <- function(id) {
         "Choose how many columns of panels to use when multiple strata are plotted."
       ))
     ),
-    add_color_customization_ui(ns, multi_group = TRUE),
+    fluidRow(
+      column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+      column(6, base_size_ui(
+        ns,
+        default = 11,
+        help_text = "Adjust the base font size used for the correlation plot."
+      ))
+    ),
     hr(),
     with_help_tooltip(
       downloadButton(ns("download_plot"), "Download Plot", style = "width: 100%;"),
@@ -85,7 +92,12 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
       multi_group = TRUE
     )
 
-    build_ggpairs_plot <- function(data, color_value, title = NULL) {
+    base_size <- base_size_server(
+      input = input,
+      default = 11
+    )
+
+    build_ggpairs_plot <- function(data, color_value, title = NULL, base_size_value = 11) {
       validate(need(is.data.frame(data) && nrow(data) > 0, "No data available for plotting."))
 
       numeric_cols <- data[, vapply(data, is.numeric, logical(1)), drop = FALSE]
@@ -106,7 +118,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
           continuous = GGally::wrap("densityDiag", fill = color_value, alpha = 0.4)
         )
       ) +
-        ggplot2::theme_minimal(base_size = 11) +
+        ggplot2::theme_minimal(base_size = base_size_value) +
         ggplot2::theme(
           strip.text = ggplot2::element_text(face = "bold", size = 9),
           panel.grid.minor = ggplot2::element_blank(),
@@ -170,7 +182,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
       if (is.null(group_var)) {
         plot_data <- data[, selected_vars, drop = FALSE]
         color_choice <- resolve_single_color(custom_colors())
-        plot_obj <- build_ggpairs_plot(plot_data, color_choice)
+        plot_obj <- build_ggpairs_plot(plot_data, color_choice, base_size_value = base_size())
         defaults <- compute_default_grid(1L)
         layout <- list(nrow = defaults$rows, ncol = defaults$cols)
         list(
@@ -204,7 +216,12 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
             next
           }
           plots[[level]] <- convert_ggmatrix_to_plot(
-            build_ggpairs_plot(subset_data, colors[[level]], title = level)
+            build_ggpairs_plot(
+              subset_data,
+              colors[[level]],
+              title = level,
+              base_size_value = base_size()
+            )
           )
         }
 

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -135,7 +135,14 @@ visualize_pca_ui <- function(id, filtered_data = NULL) {
           )
         )
       ),
-      add_color_customization_ui(ns, multi_group = TRUE),
+      fluidRow(
+        column(6, add_color_customization_ui(ns, multi_group = TRUE)),
+        column(6, base_size_ui(
+          ns,
+          default = 14,
+          help_text = "Adjust the base font size used for PCA plots."
+        ))
+      ),
       br(),
       with_help_tooltip(
         downloadButton(ns("download_plot"), "Download plot", style = "width: 100%;"),
@@ -219,6 +226,11 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
       data = color_data,
       color_var_reactive = color_var_reactive,
       multi_group = TRUE
+    )
+
+    base_size <- base_size_server(
+      input = input,
+      default = 14
     )
 
     observeEvent(available_choices(), {
@@ -494,7 +506,8 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
           subset_rows = idx,
           color_levels = color_levels,
           x_limits = x_limits,
-          y_limits = y_limits
+          y_limits = y_limits,
+          base_size = base_size()
         )
 
         if (!is.null(facet_var)) {
@@ -640,7 +653,7 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
                              show_loadings = FALSE, loading_scale = 1.2,
                              custom_colors = NULL, subset_rows = NULL,
                              color_levels = NULL, x_limits = NULL,
-                             y_limits = NULL) {
+                             y_limits = NULL, base_size = 14) {
   stopifnot(!is.null(pca_obj$x))
 
   scores <- as.data.frame(pca_obj$x[, 1:2])
@@ -700,7 +713,7 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
       shape = if (is.null(shape_var)) 16 else NULL,
       color = if (is.null(color_var)) single_color else NULL
     ) +
-    theme_minimal(base_size = 14) +
+    theme_minimal(base_size = base_size) +
     labs(
       x = x_lab,
       y = y_lab,

--- a/R/submodule_base_size.R
+++ b/R/submodule_base_size.R
@@ -1,0 +1,39 @@
+# ===============================================================
+# 🔤 Base size controls shared submodule
+# ===============================================================
+
+base_size_ui <- function(ns,
+                         input_id = "plot_base_size",
+                         default = 13,
+                         min = 6,
+                         max = 30,
+                         step = 1,
+                         help_text = "Adjust the base font size used for plot text.") {
+  tagList(
+    h5("Base size"),
+    with_help_tooltip(
+      numericInput(
+        inputId = ns(input_id),
+        label = "Base font size",
+        value = default,
+        min = min,
+        max = max,
+        step = step
+      ),
+      help_text
+    )
+  )
+}
+
+base_size_server <- function(input,
+                             input_id = "plot_base_size",
+                             default = 13) {
+  reactive({
+    value <- input[[input_id]]
+    if (is.null(value) || !is.numeric(value) || length(value) == 0 || is.na(value)) {
+      default
+    } else {
+      value
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- introduce a shared base size submodule that exposes a numeric control and reactive helper
- update visualization modules to place the base size control beside the color picker and feed the selected value into their plot themes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910867ea530832bb6d55668c6159d75)