### PR TITLE
Align base size input with color picker

### DIFF
--- a/R/submodule_base_size.R
+++ b/R/submodule_base_size.R
@@ -10,17 +10,28 @@ base_size_ui <- function(ns,
                          step = 1,
                          help_text = "Adjust the base font size used for plot text.") {
   tagList(
+    shiny::singleton(
+      tags$style(
+        HTML(
+          "\n        .ta-base-size-input .shiny-input-container,\n        .ta-base-size-input .form-group {\n          margin-bottom: 0;\n        }\n        .ta-base-size-input input.form-control {\n          height: 32px;\n          padding: 4px 10px;\n        }\n      "
+        )
+      )
+    ),
     h5("Base size"),
-    with_help_tooltip(
-      numericInput(
-        inputId = ns(input_id),
-        label = "Base font size",
-        value = default,
-        min = min,
-        max = max,
-        step = step
-      ),
-      help_text
+    div(
+      class = "ta-base-size-input",
+      with_help_tooltip(
+        numericInput(
+          inputId = ns(input_id),
+          label = NULL,
+          value = default,
+          min = min,
+          max = max,
+          step = step,
+          width = "100%"
+        ),
+        help_text
+      )
     )
   )
 }


### PR DESCRIPTION
## Summary
- remove the redundant "Base font size" label from the base size control
- add scoped styling so the base size numeric input matches the color picker height and alignment

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108939735c832bb631fa4947e09e3d)