### PR TITLE
Refactor filter module helpers

### DIFF
--- a/R/module_filter.R
+++ b/R/module_filter.R
@@ -25,125 +25,122 @@ filter_server <- function(id, uploaded_data) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     df <- reactive(uploaded_data())
-    
+
+    column_key <- function(prefix, col) paste0(prefix, col)
+
+    safe_range <- function(x) {
+      rng <- suppressWarnings(range(x, na.rm = TRUE))
+      if (any(!is.finite(rng))) rep(0, 2) else rng
+    }
+
+    numeric_step <- function(rng) {
+      span <- diff(rng)
+      if (span == 0 || any(!is.finite(span))) 1 else span / 100
+    }
+
+    build_numeric_widget <- function(col, x) {
+      rng <- safe_range(x)
+      step_val <- numeric_step(rng)
+      fluidRow(
+        column(
+          6,
+          with_help_tooltip(
+            numericInput(
+              ns(column_key("min_", col)), paste(col, "(min)"),
+              value = rng[1], min = rng[1], max = rng[2], step = step_val
+            ),
+            sprintf("Enter the smallest value to keep for %s.", col)
+          )
+        ),
+        column(
+          6,
+          with_help_tooltip(
+            numericInput(
+              ns(column_key("max_", col)), paste(col, "(max)"),
+              value = rng[2], min = rng[1], max = rng[2], step = step_val
+            ),
+            sprintf("Enter the largest value to keep for %s.", col)
+          )
+        )
+      )
+    }
+
+    build_logical_widget <- function(col) {
+      with_help_tooltip(
+        checkboxGroupInput(
+          ns(column_key("filter_", col)), label = col,
+          choices = c(TRUE, FALSE), selected = c(TRUE, FALSE), inline = TRUE
+        ),
+        sprintf("Tick the logical values you want to keep for %s.", col)
+      )
+    }
+
+    build_factor_widget <- function(col, x) {
+      choices <- sort(unique(as.character(x)))
+      with_help_tooltip(
+        selectInput(
+          ns(column_key("filter_", col)), label = col,
+          choices = choices, multiple = TRUE, selected = choices
+        ),
+        sprintf("Choose which categories should remain for %s.", col)
+      )
+    }
+
+    build_widget <- function(col) {
+      x <- df()[[col]]
+      if (is.numeric(x)) build_numeric_widget(col, x)
+      else if (is.logical(x)) build_logical_widget(col)
+      else build_factor_widget(col, x)
+    }
+
+    filter_column <- function(data, col) {
+      x <- data[[col]]
+      if (is.numeric(x)) {
+        if (all(is.na(x))) return(data)
+        min_val <- input[[column_key("min_", col)]] %||% -Inf
+        max_val <- input[[column_key("max_", col)]] %||% Inf
+        keep <- is.na(x) | (x >= min_val & x <= max_val)
+      } else {
+        sel <- input[[column_key("filter_", col)]] %||% character(0)
+        if (!length(sel)) return(data[0, , drop = FALSE])
+        keep <- is.na(x) | (as.character(x) %in% sel)
+      }
+      data[keep, , drop = FALSE]
+    }
+
     # --- 1. Column selector ---
     output$column_selector <- renderUI({
-      req(df())
+      data <- req(df())
       with_help_tooltip(
         selectInput(
           ns("columns"),
           "Select columns to filter",
-          choices = names(df()),
+          choices = names(data),
           multiple = TRUE
         ),
         "Choose which variables you want to filter before running analyses."
       )
     })
-    
+
     # --- 2. Dynamic filter widgets ---
     output$filter_widgets <- renderUI({
-      req(df())
-      cols <- input$columns
-      req(cols)
-      
-      make_numeric_widget <- function(col, x) {
-        rng <- suppressWarnings(range(x, na.rm = TRUE))
-        if (any(!is.finite(rng))) rng <- c(0, 0)
-        step_val <- ifelse(diff(rng) == 0 || any(!is.finite(diff(rng))), 1, diff(rng) / 100)
-        fluidRow(
-          column(
-            6,
-            with_help_tooltip(
-              numericInput(
-                ns(paste0("min_", col)), paste(col, "(min)"),
-                value = rng[1], min = rng[1], max = rng[2], step = step_val
-              ),
-              sprintf("Enter the smallest value to keep for %s.", col)
-            )
-          ),
-          column(
-            6,
-            with_help_tooltip(
-              numericInput(
-                ns(paste0("max_", col)), paste(col, "(max)"),
-                value = rng[2], min = rng[1], max = rng[2], step = step_val
-              ),
-              sprintf("Enter the largest value to keep for %s.", col)
-            )
-          )
-        )
-      }
-      
-      make_logical_widget <- function(col) {
-        with_help_tooltip(
-          checkboxGroupInput(
-            ns(paste0("filter_", col)), label = col,
-            choices = c(TRUE, FALSE), selected = c(TRUE, FALSE), inline = TRUE
-          ),
-          sprintf("Tick the logical values you want to keep for %s.", col)
-        )
-      }
-      
-      make_factor_widget <- function(col, x) {
-        choices <- sort(unique(as.character(x)))
-        with_help_tooltip(
-          selectInput(
-            ns(paste0("filter_", col)), label = col,
-            choices = choices, multiple = TRUE, selected = choices
-          ),
-          sprintf("Choose which categories should remain for %s.", col)
-        )
-      }
-      
-      tagList(lapply(cols, function(col) {
-        x <- df()[[col]]
-        if (is.numeric(x)) make_numeric_widget(col, x)
-        else if (is.logical(x)) make_logical_widget(col)
-        else make_factor_widget(col, x)
-      }))
+      cols <- req(input$columns)
+      tagList(lapply(cols, build_widget))
     })
-    
+
     # --- 3. Reactive filtering ---
     filtered_df <- reactive({
-      req(df())
-      data <- df()
+      data <- req(df())
       cols <- input$columns
-      
-      if (is.null(cols) || !length(cols)) return(data)
-      
-      for (col in cols) {
-        x <- data[[col]]
-
-        # Numeric columns
-        if (is.numeric(x)) {
-          min_val <- input[[paste0("min_", col)]] %||% -Inf
-          max_val <- input[[paste0("max_", col)]] %||% Inf
-          if (all(is.na(x))) {
-            next
-          }
-          keep <- is.na(x) | (x >= min_val & x <= max_val)
-          data <- data[keep, , drop = FALSE]
-        }
-        # Logical / Factor / Character
-        else {
-          sel <- input[[paste0("filter_", col)]] %||% character(0)
-          if (!length(sel)) {
-            data <- data[0, , drop = FALSE]
-            break
-          }
-          keep <- is.na(x) | (as.character(x) %in% sel)
-          data <- data[keep, , drop = FALSE]
-        }
-      }
-      
-      data
+      if (!length(cols)) return(data)
+      Reduce(filter_column, cols, init = data, right = FALSE)
     })
-    
+
     # --- 4. Preview table ---
     output$filtered_preview <- renderDT({
       datatable(filtered_df(), options = list(scrollX = TRUE, pageLength = 5))
     })
-    
+
     # --- 5. Return filtered data downstream ---
     filtered_df
   })


### PR DESCRIPTION
## Summary
- extract shared helpers for building filter widgets and column keys
- streamline reactive filtering by reducing duplicated logic while preserving behaviour

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f628f188832ba53f581a9754b360)