### PR TITLE
Streamline visualization module configuration

### DIFF
--- a/R/module_visualize.R
+++ b/R/module_visualize.R
@@ -10,10 +10,19 @@ visualize_ui <- function(id) {
 visualize_server <- function(id, filtered_data, model_fit) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    
-    # -----------------------------------------------------------
-    # 1️⃣ Reactive model info
-    # -----------------------------------------------------------
+
+    empty_state <- function(icon, title, message) {
+      div(
+        class = "empty-state card bg-light border-0 shadow-sm text-center my-5",
+        div(
+          class = "card-body py-5 px-4",
+          div(class = "empty-state-icon text-primary mb-3", HTML(icon)),
+          h4(class = "mb-2", title),
+          p(class = "text-muted mb-0", message)
+        )
+      )
+    }
+
     model_info_or_null <- reactive({
       tryCatch(
         model_fit(),
@@ -26,109 +35,79 @@ visualize_server <- function(id, filtered_data, model_fit) {
       req(info)
       info
     })
-    
-    # -----------------------------------------------------------
-    # 2️⃣ Detect analysis type (robust default)
-    # -----------------------------------------------------------
+
     analysis_type <- reactive({
       info <- model_info()
       type <- info$type %||% "oneway_anova"
       tolower(type)
     })
-    
-    # -----------------------------------------------------------
-    # 3️⃣ Visualization cache (like analysis_server)
-    # -----------------------------------------------------------
+
     vis_cache <- reactiveValues()
-    
+
     ensure_vis_server <- function(key, create_fn) {
-      if (!is.null(vis_cache[[key]])) {
-        return(vis_cache[[key]])
+      if (is.null(vis_cache[[key]])) {
+        vis_cache[[key]] <- create_fn()
       }
-      vis_cache[[key]] <- create_fn()
       vis_cache[[key]]
     }
-    
-    # -----------------------------------------------------------
-    # 4️⃣ Dynamic UI loading (lazy initialization)
-    # -----------------------------------------------------------
+
+    visualization_specs <- list(
+      oneway_anova = list(
+        id = "oneway",
+        ui = function(ns) visualize_oneway_ui(ns("oneway")),
+        server = function() visualize_oneway_server("oneway", filtered_data, model_info)
+      ),
+      twoway_anova = list(
+        id = "twoway",
+        ui = function(ns) visualize_twoway_ui(ns("twoway")),
+        server = function() visualize_twoway_server("twoway", filtered_data, model_info)
+      ),
+      pairs = list(
+        id = "ggpairs",
+        ui = function(ns) visualize_ggpairs_ui(ns("ggpairs")),
+        server = function() visualize_ggpairs_server("ggpairs", filtered_data, model_info)
+      ),
+      pca = list(
+        id = "pca",
+        ui = function(ns) visualize_pca_ui(ns("pca"), filtered_data()),
+        server = function() visualize_pca_server("pca", filtered_data, model_info)
+      ),
+      descriptive = list(
+        id = "descriptive",
+        ui = function(ns) visualize_descriptive_ui(ns("descriptive")),
+        server = function() visualize_descriptive_server("descriptive", filtered_data, model_info)
+      )
+    )
+
     output$dynamic_ui <- renderUI({
       info <- model_info_or_null()
-
       if (is.null(info)) {
-        return(
-          div(
-            class = "empty-state card bg-light border-0 shadow-sm text-center my-5",
-            div(
-              class = "card-body py-5 px-4",
-              div(
-                class = "empty-state-icon text-primary mb-3",
-                HTML("&#128221;")
-              ),
-              h4(class = "mb-2", "No analysis selected yet"),
-              p(
-                class = "text-muted mb-0",
-                "Run an analysis in the Analyze tab to unlock tailored visualizations for your results."
-              )
-            )
-          )
-        )
+        return(empty_state(
+          "&#128221;",
+          "No analysis selected yet",
+          "Run an analysis in the Analyze tab to unlock tailored visualizations for your results."
+        ))
       }
 
       type <- analysis_type()
-      switch(
-        type,
-        "oneway_anova"   = visualize_oneway_ui(ns("oneway")),
-        "twoway_anova"   = visualize_twoway_ui(ns("twoway")),
-        "pairs"          = visualize_ggpairs_ui(ns("ggpairs")),
-        "pca"            = visualize_pca_ui(ns("pca"), filtered_data()),
-        "descriptive"    = visualize_descriptive_ui(ns("descriptive")),
-        div(
-          class = "empty-state card bg-light border-0 shadow-sm text-center my-5",
-          div(
-            class = "card-body py-5 px-4",
-            div(
-              class = "empty-state-icon text-primary mb-3",
-              HTML("&#128065;")
-            ),
-            h4(class = "mb-2", "Visualization coming soon"),
-            p(
-              class = "text-muted mb-0",
-              "We're still crafting charts for this analysis type. In the meantime, explore the other visualizations available!"
-            )
-          )
-        )
+      spec <- visualization_specs[[type]]
+      if (!is.null(spec)) {
+        return(spec$ui(ns))
+      }
+
+      empty_state(
+        "&#128065;",
+        "Visualization coming soon",
+        "We're still crafting charts for this analysis type. In the meantime, explore the other visualizations available!"
       )
     })
-    
-    # -----------------------------------------------------------
-    # 5️⃣ Attach or reuse visualization servers lazily
-    # -----------------------------------------------------------
+
     observeEvent(analysis_type(), {
       type <- analysis_type()
-      
-      if (type == "oneway_anova") {
-        ensure_vis_server("oneway", function() {
-          visualize_oneway_server("oneway", filtered_data, model_info)
-        })
-      } else if (type == "twoway_anova") {
-        ensure_vis_server("twoway", function() {
-          visualize_twoway_server("twoway", filtered_data, model_info)
-        })
-      } else if (type == "pairs") {
-        ensure_vis_server("ggpairs", function() {
-          visualize_ggpairs_server("ggpairs", filtered_data, model_info)
-        })
-      } else if (type == "pca") {
-        ensure_vis_server("pca", function() {
-          visualize_pca_server("pca", filtered_data, model_info)
-        })
-      } else if (type == "descriptive") {
-        ensure_vis_server("descriptive", function() {
-          visualize_descriptive_server("descriptive", filtered_data, model_info)
-        })
+      spec <- visualization_specs[[type]]
+      if (!is.null(spec)) {
+        ensure_vis_server(spec$id, spec$server)
       }
     }, ignoreInit = FALSE)
-    
   })
 }


### PR DESCRIPTION
## Summary
- factor out shared empty state builder and visualization configuration map to remove duplicated UI/server wiring
- reuse the configuration map when rendering the visualization UI and when attaching module servers to maintain behavior while simplifying the module

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f64e10b4832b832bc1e53990feff)