### PR TITLE
Avoid grid numeric sync flicker

### DIFF
--- a/R/module_visualize_layout.R
+++ b/R/module_visualize_layout.R
@@ -115,6 +115,7 @@ consume_pending_numeric_update <- function(session, input_id) {
 schedule_numeric_update <- function(session, input_id, value) {
   mark_pending_numeric_update(session, input_id)
   session$onFlushed(function() {
+    freezeReactiveValue(session$input, input_id)
     updateNumericInput(session, input_id, value = value)
   }, once = TRUE)
 }


### PR DESCRIPTION
## Summary
- freeze grid numeric inputs before automatic sync updates so plots do not re-render multiple times

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fef245fc832bbbbbc19de9c9757b)