### PR TITLE
Prevent redundant grid invalidations

### DIFF
--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -159,10 +159,25 @@ plot_grid_server <- function(id,
     rows <- reactive(sanitize_value(input$rows, rows_min, rows_max))
     cols <- reactive(sanitize_value(input$cols, cols_min, cols_max))
 
+    combined_values <- reactiveVal(NULL)
+
+    observeEvent(
+      list(rows = rows(), cols = cols()),
+      {
+        new_values <- list(rows = rows(), cols = cols())
+        if (!identical(new_values, combined_values())) {
+          combined_values(new_values)
+        }
+      },
+      ignoreNULL = FALSE
+    )
+
+    values <- reactive(combined_values())
+
     list(
       rows = rows,
       cols = cols,
-      values = reactive(list(rows = rows(), cols = cols()))
+      values = values
     )
   })
 }


### PR DESCRIPTION
## Summary
- gate plot grid updates so the combined rows/cols reactive only invalidates when the sanitized values change
- avoid redundant cache invalidations that caused visible flicker in grid-backed plots

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110c9f9324832ba53ab2b208643aea)