### PR TITLE
Drop unused factor levels after filtering

### DIFF
--- a/R/module_filter.R
+++ b/R/module_filter.R
@@ -132,8 +132,9 @@ filter_server <- function(id, uploaded_data) {
     filtered_df <- reactive({
       data <- req(df())
       cols <- input$columns
-      if (!length(cols)) return(data)
-      Reduce(filter_column, cols, init = data, right = FALSE)
+      if (!length(cols)) return(droplevels(data))
+      filtered <- Reduce(filter_column, cols, init = data, right = FALSE)
+      droplevels(filtered)
     })
 
     # --- 4. Preview table ---


### PR DESCRIPTION
## Summary
- drop unused categorical levels when the filter module subsets data
- ensure downstream level-order widgets see only levels that remain after filtering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bf60028c832b8006a7ba81f1a93e)