### PR TITLE
Remove ANOVA barplot p-value annotations

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -146,18 +146,12 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
         )
       )
 
-      posthoc_data <- tryCatch(
-        compile_anova_results(info)$posthoc,
-        error = function(e) NULL
-      )
-
       results$barplot_mean_se <- safe_plot(
         plot_anova_barplot_meanse(
           data,
           info,
           layout_values = layout_inputs,
           line_colors = colors,
-          posthoc_all = posthoc_data,
           show_value_labels = isTRUE(input$show_bar_labels),
           base_size = base_size_value
         )

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -148,11 +148,6 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
 
       line_colors <- if (length(colors) == 0) NULL else colors
 
-      posthoc_data <- tryCatch(
-        compile_anova_results(info)$posthoc,
-        error = function(e) NULL
-      )
-
       list(
         lineplot_mean_se = safe_plot(
           plot_anova_lineplot_meanse(
@@ -169,7 +164,6 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
             info,
             layout_values = layout_inputs,
             line_colors = line_colors,
-            posthoc_all = posthoc_data,
             show_value_labels = isTRUE(input$show_bar_labels),
             base_size = base_size_value
           )


### PR DESCRIPTION
## Summary
- remove the p-value formatting utilities and significance overlays from the shared ANOVA plotting helpers
- simplify ANOVA barplot generation by dropping posthoc significance lookups and related arguments
- stop computing posthoc data solely for barplot rendering in the oneway and twoway visualization servers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c5e3ce68832ba1ff4021cc124465)