### PR TITLE
Stabilize plot grid reactive values

### DIFF
--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -159,10 +159,19 @@ plot_grid_server <- function(id,
     rows <- reactive(sanitize_value(input$rows, rows_min, rows_max))
     cols <- reactive(sanitize_value(input$cols, cols_min, cols_max))
 
+    stable_values <- reactiveVal(list(rows = NA_integer_, cols = NA_integer_))
+
+    observeEvent(list(rows(), cols()), {
+      next_values <- list(rows = rows(), cols = cols())
+      if (!identical(stable_values(), next_values)) {
+        stable_values(next_values)
+      }
+    }, ignoreNULL = FALSE)
+
     list(
       rows = rows,
       cols = cols,
-      values = reactive(list(rows = rows(), cols = cols()))
+      values = reactive(stable_values())
     )
   })
 }


### PR DESCRIPTION
## Summary
- publish plot grid values through a stable reactive that only updates when rows/cols change
- prevent redundant cache invalidations and plot flicker caused by duplicate grid events

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110c9f9324832ba53ab2b208643aea)