### PR TITLE
Persist descriptive visualization selection

### DIFF
--- a/R/module_visualize.R
+++ b/R/module_visualize.R
@@ -43,6 +43,8 @@ visualize_server <- function(id, filtered_data, model_fit) {
     })
 
     vis_cache <- reactiveValues()
+    selection_memory <- reactiveValues()
+    active_selection_key <- reactiveVal(NULL)
 
     ensure_vis_server <- function(key, create_fn) {
       if (is.null(vis_cache[[key]])) {
@@ -55,27 +57,35 @@ visualize_server <- function(id, filtered_data, model_fit) {
       oneway_anova = list(
         id = "oneway",
         ui = function(ns) visualize_oneway_ui(ns("oneway")),
-        server = function() visualize_oneway_server("oneway", filtered_data, model_info)
+        server = function(...) visualize_oneway_server("oneway", filtered_data, model_info)
       ),
       twoway_anova = list(
         id = "twoway",
         ui = function(ns) visualize_twoway_ui(ns("twoway")),
-        server = function() visualize_twoway_server("twoway", filtered_data, model_info)
+        server = function(...) visualize_twoway_server("twoway", filtered_data, model_info)
       ),
       pairs = list(
         id = "ggpairs",
         ui = function(ns) visualize_ggpairs_ui(ns("ggpairs")),
-        server = function() visualize_ggpairs_server("ggpairs", filtered_data, model_info)
+        server = function(...) visualize_ggpairs_server("ggpairs", filtered_data, model_info)
       ),
       pca = list(
         id = "pca",
         ui = function(ns) visualize_pca_ui(ns("pca"), filtered_data()),
-        server = function() visualize_pca_server("pca", filtered_data, model_info)
+        server = function(...) visualize_pca_server("pca", filtered_data, model_info)
       ),
       descriptive = list(
         id = "descriptive",
         ui = function(ns) visualize_descriptive_ui(ns("descriptive")),
-        server = function() visualize_descriptive_server("descriptive", filtered_data, model_info)
+        server = function(selection, save_selection) {
+          visualize_descriptive_server(
+            "descriptive",
+            filtered_data,
+            model_info,
+            selection,
+            save_selection
+          )
+        }
       )
     )
 
@@ -105,9 +115,30 @@ visualize_server <- function(id, filtered_data, model_fit) {
     observeEvent(analysis_type(), {
       type <- analysis_type()
       spec <- visualization_specs[[type]]
-      if (!is.null(spec)) {
-        ensure_vis_server(spec$id, spec$server)
+
+      if (is.null(spec)) {
+        return(NULL)
       }
+
+      key <- spec$id
+      previous_key <- active_selection_key()
+
+      if (!identical(previous_key, key)) {
+        selection_memory[[key]] <- NULL
+        active_selection_key(key)
+      }
+
+      ensure_vis_server(
+        key,
+        function() {
+          spec$server(
+            selection = reactive(selection_memory[[key]]),
+            save_selection = function(value) {
+              selection_memory[[key]] <- value
+            }
+          )
+        }
+      )
     }, ignoreInit = FALSE)
   })
 }


### PR DESCRIPTION
## Summary
- add a visualization selection cache keyed by module so stored choices survive UI rebuilds
- pass cached values into the descriptive visualization server and restore the last plot selection without forcing a rerender

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130a3e2be0832bb318e61ff9624f0b)