### PR TITLE
Adjust bar plot value label size based on base size control

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1207,7 +1207,7 @@ build_single_factor_barplot <- function(stats_df,
     )
   
   if (isTRUE(show_value_labels)) {
-    plot_obj <- add_bar_value_labels(plot_obj, stats_df, factor1, format_numeric_labels)
+    plot_obj <- add_bar_value_labels(plot_obj, stats_df, factor1, format_numeric_labels, base_size)
   }
   
   if (!is.null(posthoc_entry)) {
@@ -1264,7 +1264,7 @@ build_two_factor_barplot <- function(stats_df,
     scale_fill_manual(values = palette)
   
   if (isTRUE(show_value_labels)) {
-    plot_obj <- add_grouped_bar_value_labels(plot_obj, stats_df, factor1, factor2, format_numeric_labels, dodge)
+    plot_obj <- add_grouped_bar_value_labels(plot_obj, stats_df, factor1, factor2, format_numeric_labels, dodge, base_size)
   }
   
   if (!is.null(nested_posthoc)) {
@@ -1277,7 +1277,7 @@ build_two_factor_barplot <- function(stats_df,
 # ===============================================================
 # 🔹 Helper: Add value labels to single-factor barplots
 # ===============================================================
-add_bar_value_labels <- function(plot_obj, stats_df, factor1, format_numeric_labels) {
+add_bar_value_labels <- function(plot_obj, stats_df, factor1, format_numeric_labels, base_size) {
   label_df <- stats_df |>
     dplyr::mutate(
       .se = dplyr::coalesce(se, 0),
@@ -1285,13 +1285,13 @@ add_bar_value_labels <- function(plot_obj, stats_df, factor1, format_numeric_lab
       label_y = ifelse(mean >= 0, mean + .se, mean - .se),
       label_vjust = ifelse(mean >= 0, -0.4, 1.2)
     )
-  
+
   plot_obj +
     geom_text(
       data = label_df,
       aes(x = !!sym(factor1), y = label_y, label = label_text, vjust = label_vjust),
       color = "gray20",
-      size = 3.8,
+      size = compute_label_text_size(base_size),
       fontface = "bold",
       inherit.aes = FALSE
     ) +
@@ -1301,7 +1301,7 @@ add_bar_value_labels <- function(plot_obj, stats_df, factor1, format_numeric_lab
 # ===============================================================
 # 🔹 Helper: Add value labels to grouped (two-factor) barplots
 # ===============================================================
-add_grouped_bar_value_labels <- function(plot_obj, stats_df, factor1, factor2, format_numeric_labels, dodge) {
+add_grouped_bar_value_labels <- function(plot_obj, stats_df, factor1, factor2, format_numeric_labels, dodge, base_size) {
   label_df <- stats_df |>
     dplyr::mutate(
       .se = dplyr::coalesce(se, 0),
@@ -1323,7 +1323,7 @@ add_grouped_bar_value_labels <- function(plot_obj, stats_df, factor1, factor2, f
       ),
       position = dodge,
       color = "gray20",
-      size = 3.6,
+      size = compute_label_text_size(base_size),
       fontface = "bold",
       inherit.aes = FALSE
     ) +

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -214,7 +214,12 @@ apply_value_scale <- function(plot, show_proportions, show_value_labels) {
   }
 }
 
-add_value_labels <- function(plot, data, show_value_labels, show_proportions, position = NULL) {
+add_value_labels <- function(plot,
+                             data,
+                             show_value_labels,
+                             show_proportions,
+                             position = NULL,
+                             base_size = 13) {
   if (!isTRUE(show_value_labels)) return(plot)
 
   label_df <- format_value_labels(data, show_proportions)
@@ -227,7 +232,7 @@ add_value_labels <- function(plot, data, show_value_labels, show_proportions, po
       aes(label = label_text, y = label_y, vjust = label_vjust),
       position = position,
       color = "gray20",
-      size = 3.5,
+      size = compute_label_text_size(base_size),
       fontface = "bold"
     )
 }
@@ -319,7 +324,7 @@ build_descriptive_categorical_plot <- function(df,
         labs(title = var, x = NULL, y = y_label, fill = group_col) +
         theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
-      p <- add_value_labels(p, count_df, show_value_labels, show_proportions, group_dodge)
+      p <- add_value_labels(p, count_df, show_value_labels, show_proportions, group_dodge, base_size)
       p <- apply_value_scale(p, show_proportions, show_value_labels)
       p
     } else {
@@ -347,7 +352,7 @@ build_descriptive_categorical_plot <- function(df,
         labs(title = var, x = NULL, y = y_label) +
         theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
-      p <- add_value_labels(p, count_df, show_value_labels, show_proportions)
+      p <- add_value_labels(p, count_df, show_value_labels, show_proportions, base_size = base_size)
       p <- apply_value_scale(p, show_proportions, show_value_labels)
       p
     }

--- a/R/submodule_base_size.R
+++ b/R/submodule_base_size.R
@@ -48,3 +48,17 @@ base_size_server <- function(input,
     }
   })
 }
+
+compute_label_text_size <- function(base_size,
+                                    divisor = 4,
+                                    min_size = 2.5,
+                                    max_size = 6) {
+  if (is.null(base_size) || !is.numeric(base_size) || !is.finite(base_size)) {
+    return(min_size)
+  }
+
+  size <- base_size / divisor
+  size <- max(min_size, size)
+  size <- min(max_size, size)
+  size
+}


### PR DESCRIPTION
## Summary
- scale ANOVA bar plot value label text using the selected base font size
- respect the base size control for descriptive categorical bar plot value labels
- add a helper to derive consistent label text sizing from the base size value

## Testing
- Not run (Rscript is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131b8d7884832bb845588ce4db1d5e)