### PR TITLE
Fix render flicker across descriptive plots

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -131,16 +131,26 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       )
     })
     
-    size_val <- reactiveVal(list(w = 400, h = 300))
-    
-    observeEvent(plot_info(), {
+    plot_dimensions <- reactive({
       req(module_active())
       info <- plot_info()
       lay <- info$layout
-      nrow_l <- if (is.null(lay) || is.null(lay$nrow) || is.na(lay$nrow)) 1L else as.integer(lay$nrow)
-      ncol_l <- if (is.null(lay) || is.null(lay$ncol) || is.na(lay$ncol)) 1L else as.integer(lay$ncol)
-      size_val(list(w = plot_width() * ncol_l, h = plot_height() * nrow_l))
-    }, ignoreInit = FALSE)
+
+      nrow_l <- 1L
+      if (!is.null(lay) && !is.null(lay$nrow) && !is.na(lay$nrow)) {
+        nrow_l <- as.integer(lay$nrow)
+      }
+
+      ncol_l <- 1L
+      if (!is.null(lay) && !is.null(lay$ncol) && !is.na(lay$ncol)) {
+        ncol_l <- as.integer(lay$ncol)
+      }
+
+      list(
+        width = plot_width() * ncol_l,
+        height = plot_height() * nrow_l
+      )
+    })
     
     output$grid_warning <- renderUI({
       req(module_active())
@@ -154,28 +164,28 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         req(module_active())
         info <- plot_info()
         req(is.null(info$warning), !is.null(info$plot))
-        s <- size_val()
+        s <- plot_dimensions()
         ggplot2::ggsave(
           filename = file,
           plot = info$plot,
           device = "png",
           dpi = 300,
-          width  = s$w / 96,
-          height = s$h / 96,
+          width  = s$width / 96,
+          height = s$height / 96,
           units = "in",
           limitsize = FALSE
         )
       }
     )
-    
+
     output$plot <- renderPlot({
       req(module_active())
       info <- plot_info()
       if (!is.null(info$warning) || is.null(info$plot)) return(NULL)
       print(info$plot)
     },
-    width = function() { size_val()$w },
-    height = function() { size_val()$h },
+    width = function() { plot_dimensions()$width },
+    height = function() { plot_dimensions()$height },
     res = 96)
   })
 }

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -164,16 +164,26 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       )
     })
     
-    size_val <- reactiveVal(list(w = 200, h = 800))
-    
-    observeEvent(plot_info(), {
+    plot_dimensions <- reactive({
       req(module_active())
       info <- plot_info()
       lay <- info$layout
-      nrow_l <- if (is.null(lay) || is.null(lay$nrow) || is.na(lay$nrow)) 1L else as.integer(lay$nrow)
-      ncol_l <- if (is.null(lay) || is.null(lay$ncol) || is.na(lay$ncol)) 1L else as.integer(lay$ncol)
-      size_val(list(w = plot_width() * ncol_l, h = plot_height() * nrow_l))
-    }, ignoreInit = FALSE)
+
+      nrow_l <- 1L
+      if (!is.null(lay) && !is.null(lay$nrow) && !is.na(lay$nrow)) {
+        nrow_l <- as.integer(lay$nrow)
+      }
+
+      ncol_l <- 1L
+      if (!is.null(lay) && !is.null(lay$ncol) && !is.na(lay$ncol)) {
+        ncol_l <- as.integer(lay$ncol)
+      }
+
+      list(
+        width = plot_width() * ncol_l,
+        height = plot_height() * nrow_l
+      )
+    })
     
     output$grid_warning <- renderUI({
       req(module_active())
@@ -187,28 +197,28 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         req(module_active())
         info <- plot_info()
         req(is.null(info$warning), !is.null(info$plot))
-        s <- size_val()
+        s <- plot_dimensions()
         ggplot2::ggsave(
           filename = file,
           plot = info$plot,
           device = "png",
           dpi = 300,
-          width  = s$w / 96,
-          height = s$h / 96,
+          width  = s$width / 96,
+          height = s$height / 96,
           units = "in",
           limitsize = FALSE
         )
       }
     )
-    
+
     output$plot <- renderPlot({
       req(module_active())
       info <- plot_info()
       if (!is.null(info$warning) || is.null(info$plot)) return(NULL)
       print(info$plot)
     },
-    width = function() { size_val()$w },
-    height = function() { size_val()$h },
+    width = function() { plot_dimensions()$width },
+    height = function() { plot_dimensions()$height },
     res = 96)
   })
 }

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -127,16 +127,26 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       )
     })
     
-    size_val <- reactiveVal(list(w = 400, h = 300))
-    
-    observeEvent(plot_info(), {
+    plot_dimensions <- reactive({
       req(module_active())
       info <- plot_info()
       lay <- info$layout
-      nrow_l <- if (is.null(lay) || is.null(lay$nrow) || is.na(lay$nrow)) 1L else as.integer(lay$nrow)
-      ncol_l <- if (is.null(lay) || is.null(lay$ncol) || is.na(lay$ncol)) 1L else as.integer(lay$ncol)
-      size_val(list(w = plot_width() * ncol_l, h = plot_height() * nrow_l))
-    }, ignoreInit = FALSE)
+
+      nrow_l <- 1L
+      if (!is.null(lay) && !is.null(lay$nrow) && !is.na(lay$nrow)) {
+        nrow_l <- as.integer(lay$nrow)
+      }
+
+      ncol_l <- 1L
+      if (!is.null(lay) && !is.null(lay$ncol) && !is.na(lay$ncol)) {
+        ncol_l <- as.integer(lay$ncol)
+      }
+
+      list(
+        width = plot_width() * ncol_l,
+        height = plot_height() * nrow_l
+      )
+    })
     
     output$grid_warning <- renderUI({
       req(module_active())
@@ -150,28 +160,28 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
         req(module_active())
         info <- plot_info()
         req(is.null(info$warning), !is.null(info$plot))
-        s <- size_val()
+        s <- plot_dimensions()
         ggplot2::ggsave(
           filename = file,
           plot = info$plot,
           device = "png",
           dpi = 300,
-          width  = s$w / 96,
-          height = s$h / 96,
+          width  = s$width / 96,
+          height = s$height / 96,
           units = "in",
           limitsize = FALSE
         )
       }
     )
-    
+
     output$plot <- renderPlot({
       req(module_active())
       info <- plot_info()
       if (!is.null(info$warning) || is.null(info$plot)) return(NULL)
       print(info$plot)
     },
-    width = function() { size_val()$w },
-    height = function() { size_val()$h },
+    width = function() { plot_dimensions()$width },
+    height = function() { plot_dimensions()$height },
     res = 96)
   })
 }


### PR DESCRIPTION
## Summary
- compute numeric boxplot dimensions directly from the resolved layout
- reuse those dimensions for rendering and downloads to avoid initial resize flicker
- apply the same layout-derived sizing to categorical barplots and numeric histograms

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131b5923d4832b848912ceb93da70a)