### PR TITLE
Refactor reactive helper usage before deployment

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -57,11 +57,6 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
-    resolve_input_value <- function(x) {
-      if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
-    }
-    
     module_active <- reactive({
       if (is.null(is_active)) TRUE else isTRUE(is_active())
     })
@@ -74,7 +69,7 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
     color_var_reactive <- reactive({
       info <- summary_info()
       if (is.null(info)) return(NULL)
-      g <- resolve_input_value(info$group_var)
+      g <- resolve_reactive(info$group_var)
       dat <- filtered_data()
       if (is.null(g) || identical(g, "") || identical(g, "None")) return(NULL)
       if (is.null(dat) || !is.data.frame(dat) || !g %in% names(dat)) return(NULL)
@@ -109,13 +104,13 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       req(module_active())
       s <- state()
       req(!is.null(s$info))
-      processed <- resolve_input_value(s$info$processed_data)
+      processed <- resolve_reactive(s$info$processed_data)
       dat <- if (!is.null(processed)) processed else s$dat
       req(!is.null(dat), is.data.frame(dat), nrow(dat) > 0)
-      
-      selected_vars <- resolve_input_value(s$info$selected_vars)
-      group_var     <- resolve_input_value(s$info$group_var)
-      strata_levels <- resolve_input_value(s$info$strata_levels)
+
+      selected_vars <- resolve_reactive(s$info$selected_vars)
+      group_var     <- resolve_reactive(s$info$group_var)
+      strata_levels <- resolve_reactive(s$info$strata_levels)
       
       build_descriptive_categorical_plot(
         df                = dat,

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -49,12 +49,6 @@ metric_plot_ui <- function(id) {
 visualize_cv_plot_ui <- visualize_outliers_plot_ui <- visualize_missing_plot_ui <- metric_plot_ui
 
 
-# ---- Shared computation helpers ----
-resolve_metric_input <- function(x) {
-  if (is.null(x)) return(NULL)
-  if (is.reactive(x)) x() else x
-}
-
 safe_cv <- function(x) {
   m <- mean(x, na.rm = TRUE)
   s <- stats::sd(x, na.rm = TRUE)
@@ -224,7 +218,7 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       info <- summary_info()
       if (is.null(info)) return(NULL)
 
-      group_var <- resolve_metric_input(info$group_var)
+      group_var <- resolve_reactive(info$group_var)
       if (is.null(group_var) || group_var %in% c("", "None")) return(NULL)
 
       dat <- filtered_data()
@@ -270,15 +264,15 @@ metric_module_server <- function(id, filtered_data, summary_info, metric_key,
       info <- summary_info()
       validate(need(!is.null(info), "Summary not available."))
 
-      processed <- resolve_metric_input(info$processed_data)
+      processed <- resolve_reactive(info$processed_data)
       dat <- if (!is.null(processed)) processed else filtered_data()
 
       validate(need(!is.null(dat) && is.data.frame(dat) && nrow(dat) > 0, "No data available."))
 
-      selected_vars <- resolve_metric_input(info$selected_vars)
-      group_var <- resolve_metric_input(info$group_var)
-      strata_levels <- resolve_metric_input(info$strata_levels)
-      group_label <- resolve_metric_input(info$group_label)
+      selected_vars <- resolve_reactive(info$selected_vars)
+      group_var <- resolve_reactive(info$group_var)
+      strata_levels <- resolve_reactive(info$strata_levels)
+      group_label <- resolve_reactive(info$group_label)
 
       numeric_vars <- names(dat)[vapply(dat, is.numeric, logical(1))]
       if (!is.null(selected_vars) && length(selected_vars) > 0) {

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -64,11 +64,6 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
-    resolve_input_value <- function(x) {
-      if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
-    }
-    
     module_active <- reactive({
       if (is.null(is_active)) TRUE else isTRUE(is_active())
     })
@@ -81,7 +76,7 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
     color_var_reactive <- reactive({
       info <- summary_info()
       if (is.null(info)) return(NULL)
-      g <- resolve_input_value(info$group_var)
+      g <- resolve_reactive(info$group_var)
       dat <- filtered_data()
       if (is.null(g) || identical(g, "") || identical(g, "None")) return(NULL)
       if (is.null(dat) || !is.data.frame(dat) || !g %in% names(dat)) return(NULL)
@@ -143,12 +138,12 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       req(module_active())
       s <- state()
       req(!is.null(s$info))
-      processed <- resolve_input_value(s$info$processed_data)
+      processed <- resolve_reactive(s$info$processed_data)
       dat <- if (!is.null(processed)) processed else s$dat
       req(!is.null(dat), is.data.frame(dat), nrow(dat) > 0)
-      
-      selected_vars <- resolve_input_value(s$info$selected_vars)
-      group_var     <- resolve_input_value(s$info$group_var)
+
+      selected_vars <- resolve_reactive(s$info$selected_vars)
+      group_var     <- resolve_reactive(s$info$group_var)
       
       build_descriptive_numeric_boxplot(
         df                = dat,

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -55,11 +55,6 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
-    resolve_input_value <- function(x) {
-      if (is.null(x)) return(NULL)
-      if (is.reactive(x)) x() else x
-    }
-    
     module_active <- reactive({
       if (is.null(is_active)) TRUE else isTRUE(is_active())
     })
@@ -72,7 +67,7 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
     color_var_reactive <- reactive({
       info <- summary_info()
       if (is.null(info)) return(NULL)
-      g <- resolve_input_value(info$group_var)
+      g <- resolve_reactive(info$group_var)
       dat <- filtered_data()
       if (is.null(g) || identical(g, "") || identical(g, "None")) return(NULL)
       if (is.null(dat) || !is.data.frame(dat) || !g %in% names(dat)) return(NULL)
@@ -106,13 +101,13 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       req(module_active())
       s <- state()
       req(!is.null(s$info))
-      processed <- resolve_input_value(s$info$processed_data)
+      processed <- resolve_reactive(s$info$processed_data)
       dat <- if (!is.null(processed)) processed else s$dat
       req(!is.null(dat), is.data.frame(dat), nrow(dat) > 0)
-      
-      selected_vars <- resolve_input_value(s$info$selected_vars)
-      group_var     <- resolve_input_value(s$info$group_var)
-      strata_levels <- resolve_input_value(s$info$strata_levels)
+
+      selected_vars <- resolve_reactive(s$info$selected_vars)
+      group_var     <- resolve_reactive(s$info$group_var)
+      strata_levels <- resolve_reactive(s$info$strata_levels)
       
       build_descriptive_numeric_histogram(
         df            = dat,

--- a/R/helpers_reactive.R
+++ b/R/helpers_reactive.R
@@ -1,0 +1,9 @@
+resolve_reactive <- function(value, default = NULL) {
+  if (is.null(value)) {
+    return(default)
+  }
+
+  resolved <- if (is.reactive(value)) value() else value
+
+  if (is.null(resolved)) default else resolved
+}

--- a/R/module_analysis.R
+++ b/R/module_analysis.R
@@ -125,7 +125,7 @@ analysis_server <- function(id, filtered_data) {
 
       # --- Standardize all outputs to a reactive returning a list ---
       standardized <- reactive({
-        val <- if (is.reactive(result)) result() else result
+        val <- resolve_reactive(result)
         req(val)
         fill_defaults(val)
       })

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -41,7 +41,6 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     
-    resolve_input_value <- function(x) if (is.reactive(x)) x() else x
     sanitize_numeric <- function(value, default, min_val, max_val) {
       v <- suppressWarnings(as.numeric(value))
       if (!length(v) || is.na(v)) return(default)
@@ -54,7 +53,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
     color_var_reactive <- reactive({
       info <- correlation_info()
       if (is.null(info)) return(NULL)
-      group_var <- resolve_input_value(info$group_var)
+      group_var <- resolve_reactive(info$group_var)
       if (is.null(group_var)) return(NULL)
       group_var <- as.character(group_var)[1]
       if (identical(group_var, "None") || !nzchar(group_var)) return(NULL)
@@ -111,7 +110,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
       info <- correlation_info()
       validate(need(!is.null(info), "Correlation results are not available."))
       results_accessor <- info$results
-      results <- resolve_input_value(results_accessor)
+      results <- resolve_reactive(results_accessor)
       validate(need(!is.null(results), "Run the correlation analysis to generate plots."))
       
       if (!is.null(results$message)) validate(need(FALSE, results$message))
@@ -119,16 +118,16 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
       data <- filtered_data()
       validate(need(!is.null(data) && nrow(data) > 0, "No data available."))
       
-      selected_vars <- resolve_input_value(results$selected_vars)
+      selected_vars <- resolve_reactive(results$selected_vars)
       if (is.null(selected_vars) || length(selected_vars) < 2)
         selected_vars <- names(data)[vapply(data, is.numeric, logical(1))]
       validate(need(length(selected_vars) >= 2, "Need at least two numeric columns for GGPairs plot."))
       
-      group_var <- resolve_input_value(info$group_var)
+      group_var <- resolve_reactive(info$group_var)
       if (!is.null(group_var)) group_var <- as.character(group_var)[1]
       if (is.null(group_var) || identical(group_var, "None") || !nzchar(group_var)) group_var <- NULL
       
-      strata_order <- resolve_input_value(info$strata_order)
+      strata_order <- resolve_reactive(info$strata_order)
       
       if (is.null(group_var)) {
         plot_data <- data[, selected_vars, drop = FALSE]

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -207,14 +207,8 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
       entry <- pca_entry()
       if (!is.null(entry) && !is.null(entry$data)) {
         entry$data
-      } else if (!is.null(filtered_data)) {
-        if (is.reactive(filtered_data)) {
-          filtered_data()
-        } else {
-          filtered_data
-        }
       } else {
-        NULL
+        resolve_reactive(filtered_data)
       }
     })
 

--- a/app.R
+++ b/app.R
@@ -21,7 +21,6 @@ library(skimr)
 library(tidyr)
 library(zoo)
 
-options(shiny.autoreload = TRUE)
 options(shiny.maxRequestSize = 200 * 1024^2)
 
 for (f in list.files("R", full.names = TRUE, pattern = "\\.R$")) source(f)


### PR DESCRIPTION
## Summary
- remove the development-only shiny autoreload option from `app.R`
- add a shared `resolve_reactive()` helper to eliminate duplicated inline functions
- update visualization and analysis modules to rely on the shared helper for cleaner reactive handling

## Testing
- Not run (Rscript is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132207a394832ba2de6f07273c6f4a)