### PR TITLE
Fix plot sizing observers to react to width/height inputs

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -150,23 +150,31 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
     
     size_val <- reactiveVal(list(w = 400, h = 300))
     
-    observeEvent(plot_info(), {
+    observe({
       req(module_active())
       info <- plot_info()
+      req(info)
+
+      width_input <- suppressWarnings(as.numeric(input$plot_width))
+      height_input <- suppressWarnings(as.numeric(input$plot_height))
+
+      plot_w <- if (is.na(width_input) || width_input <= 0) 400 else width_input
+      plot_h <- if (is.na(height_input) || height_input <= 0) 300 else height_input
+
       layout <- info$layout
       if (is.null(layout)) {
-        size_val(list(w = input$plot_width, h = input$plot_height))
+        size_val(list(w = plot_w, h = plot_h))
       } else {
         strata <- layout$strata
         responses <- layout$responses
         nrow_l <- (strata$rows %||% 1L) * (responses$rows %||% 1L)
         ncol_l <- (strata$cols %||% 1L) * (responses$cols %||% 1L)
         size_val(list(
-          w = input$plot_width  * ncol_l,
-          h = input$plot_height * nrow_l
+          w = plot_w * ncol_l,
+          h = plot_h * nrow_l
         ))
       }
-    }, ignoreInit = FALSE)
+    })
     
     output$layout_controls <- renderUI({
       info <- model_info()

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -154,23 +154,31 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     
     size_val <- reactiveVal(list(w = 400, h = 300))
     
-    observeEvent(plot_info(), {
+    observe({
       req(module_active())
       info <- plot_info()
+      req(info)
+
+      width_input <- suppressWarnings(as.numeric(input$plot_width))
+      height_input <- suppressWarnings(as.numeric(input$plot_height))
+
+      plot_w <- if (is.na(width_input) || width_input <= 0) 400 else width_input
+      plot_h <- if (is.na(height_input) || height_input <= 0) 300 else height_input
+
       layout <- info$layout
       if (is.null(layout)) {
-        size_val(list(w = input$plot_width, h = input$plot_height))
+        size_val(list(w = plot_w, h = plot_h))
       } else {
         strata <- layout$strata
         responses <- layout$responses
         nrow_l <- (strata$rows %||% 1L) * (responses$rows %||% 1L)
         ncol_l <- (strata$cols %||% 1L) * (responses$cols %||% 1L)
         size_val(list(
-          w = input$plot_width  * ncol_l,
-          h = input$plot_height * nrow_l
+          w = plot_w * ncol_l,
+          h = plot_h * nrow_l
         ))
       }
-    }, ignoreInit = FALSE)
+    })
     
     output$layout_controls <- renderUI({
       info <- model_info()

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -183,20 +183,28 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
     # ---- New unified sizing logic ----
     size_val <- reactiveVal(list(w = 800, h = 600))
     
-    observeEvent(plot_info(), {
+    observe({
       info <- plot_info()
+      req(info)
+
       layout <- info$layout
+      base_w <- plot_width()
+      base_h <- plot_height()
+
+      plot_w <- if (is.null(base_w) || is.na(base_w) || base_w <= 0) 800 else base_w
+      plot_h <- if (is.null(base_h) || is.na(base_h) || base_h <= 0) 600 else base_h
+
       if (is.null(layout)) {
-        size_val(list(w = plot_width(), h = plot_height()))
+        size_val(list(w = plot_w, h = plot_h))
       } else {
         nrow_l <- ifelse(is.null(layout$nrow), 1L, as.integer(layout$nrow))
         ncol_l <- ifelse(is.null(layout$ncol), 1L, as.integer(layout$ncol))
         size_val(list(
-          w = plot_width()  * ncol_l,
-          h = plot_height() * nrow_l
+          w = plot_w * ncol_l,
+          h = plot_h * nrow_l
         ))
       }
-    }, ignoreInit = FALSE)
+    })
     
     output$download_plot <- downloadHandler(
       filename = function() paste0("pairwise_correlation_ggpairs_", Sys.Date(), ".png"),

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -498,19 +498,21 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
     # ---- Unified sizing logic ----
     size_val <- reactiveVal(list(w = 800, h = 600))
     
-    observeEvent(plot_info(), {
+    observe({
       info <- plot_info()
+      req(info)
+
       layout <- info$layout
       base_w <- suppressWarnings(as.numeric(input$plot_width))
       base_h <- suppressWarnings(as.numeric(input$plot_height))
-      
+
       valid_size <- function(x, default) {
         if (is.na(x) || x <= 0) default else x
       }
-      
+
       subplot_w <- valid_size(base_w, 400)
       subplot_h <- valid_size(base_h, 300)
-      
+
       if (is.null(layout)) {
         size_val(list(w = subplot_w, h = subplot_h))
       } else {
@@ -518,7 +520,7 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
         nrow <- if (!is.null(layout$nrow)) max(1, layout$nrow) else 1
         size_val(list(w = subplot_w * ncol, h = subplot_h * nrow))
       }
-    }, ignoreInit = FALSE)
+    })
     
     output$plot_warning <- renderUI({
       info <- plot_info()


### PR DESCRIPTION
## Summary
- ensure plot sizing observers across visualization modules respond to plot width and height inputs
- fall back to default subplot dimensions when width or height values are missing or invalid so layout sizing stays stable

## Testing
- not run (Shiny UI changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913274cf338832ba13b8972a4f66f98)