### PR TITLE
Display computed grid dimensions in plot controls

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -146,8 +146,32 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       res <- compute_all_plots(s$data, s$info, layout_inputs, s$colors, s$base_size, s$show_labels)
       res[[if (!is.null(s$plot_type) && s$plot_type %in% names(res)) s$plot_type else "lineplot_mean_se"]]
     })
-    
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout)) {
+        if (!is.null(layout$strata)) {
+          strata_grid$set(rows = layout$strata$rows, cols = layout$strata$cols)
+        }
+        if (!is.null(layout$responses)) {
+          response_grid$set(rows = layout$responses$rows, cols = layout$responses$cols)
+        }
+      } else if (!is.null(defaults)) {
+        if (!is.null(defaults$strata)) {
+          strata_grid$set(rows = defaults$strata$rows, cols = defaults$strata$cols)
+        }
+        if (!is.null(defaults$responses)) {
+          response_grid$set(rows = defaults$responses$rows, cols = defaults$responses$cols)
+        }
+      }
+    }, ignoreNULL = TRUE)
+
+
     size_val <- reactiveVal(list(w = 400, h = 300))
     
     observe({

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -151,7 +151,31 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       res <- compute_all_plots(s$data, s$info, layout_inputs, s$colors, s$base_size, s$show_labels)
       res[[if (!is.null(s$plot_type) && s$plot_type %in% names(res)) s$plot_type else "lineplot_mean_se"]]
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout)) {
+        if (!is.null(layout$strata)) {
+          strata_grid$set(rows = layout$strata$rows, cols = layout$strata$cols)
+        }
+        if (!is.null(layout$responses)) {
+          response_grid$set(rows = layout$responses$rows, cols = layout$responses$cols)
+        }
+      } else if (!is.null(defaults)) {
+        if (!is.null(defaults$strata)) {
+          strata_grid$set(rows = defaults$strata$rows, cols = defaults$strata$cols)
+        }
+        if (!is.null(defaults$responses)) {
+          response_grid$set(rows = defaults$responses$rows, cols = defaults$responses$cols)
+        }
+      }
+    }, ignoreNULL = TRUE)
+
     size_val <- reactiveVal(list(w = 400, h = 300))
     
     observe({

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -125,7 +125,21 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         base_size         = s$base_size
       )
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout) && !is.null(layout$nrow) && !is.null(layout$ncol)) {
+        grid$set(rows = layout$nrow, cols = layout$ncol)
+      } else if (!is.null(defaults)) {
+        grid$set(rows = defaults$rows, cols = defaults$cols)
+      }
+    }, ignoreNULL = TRUE)
+
     plot_dimensions <- reactive({
       req(module_active())
       info <- plot_info()

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -158,7 +158,21 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         base_size         = s$base_size
       )
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout) && !is.null(layout$nrow) && !is.null(layout$ncol)) {
+        grid$set(rows = layout$nrow, cols = layout$ncol)
+      } else if (!is.null(defaults)) {
+        grid$set(rows = defaults$rows, cols = defaults$cols)
+      }
+    }, ignoreNULL = TRUE)
+
     plot_dimensions <- reactive({
       req(module_active())
       info <- plot_info()

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -121,7 +121,21 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
         base_size     = s$base_size
       )
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout) && !is.null(layout$nrow) && !is.null(layout$ncol)) {
+        grid$set(rows = layout$nrow, cols = layout$ncol)
+      } else if (!is.null(defaults)) {
+        grid$set(rows = defaults$rows, cols = defaults$cols)
+      }
+    }, ignoreNULL = TRUE)
+
     plot_dimensions <- reactive({
       req(module_active())
       info <- plot_info()

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -179,7 +179,21 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
         )
       }
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout) && !is.null(layout$nrow) && !is.null(layout$ncol)) {
+        grid_inputs$set(rows = layout$nrow, cols = layout$ncol)
+      } else if (!is.null(defaults)) {
+        grid_inputs$set(rows = defaults$rows, cols = defaults$cols)
+      }
+    }, ignoreNULL = TRUE)
+
     # ---- New unified sizing logic ----
     size_val <- reactiveVal(list(w = 800, h = 600))
     

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -495,6 +495,20 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
       )
     })
 
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      if (is.null(info)) return()
+
+      layout <- info$layout
+      defaults <- info$defaults
+
+      if (!is.null(layout) && !is.null(layout$nrow) && !is.null(layout$ncol)) {
+        facet_grid_inputs$set(rows = layout$nrow, cols = layout$ncol)
+      } else if (!is.null(defaults)) {
+        facet_grid_inputs$set(rows = defaults$rows, cols = defaults$cols)
+      }
+    }, ignoreNULL = TRUE)
+
     # ---- Unified sizing logic ----
     size_val <- reactiveVal(list(w = 800, h = 600))
     

--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -145,20 +145,39 @@ plot_grid_server <- function(id,
       v <- min(as.integer(max_value), v)
       as.integer(v)
     }
-    
+
     rows_raw <- reactive(sanitize(input$rows, rows_min, rows_max))
     cols_raw <- reactive(sanitize(input$cols, cols_min, cols_max))
-    
+
     values_raw <- reactive(list(rows = rows_raw(), cols = cols_raw()))
     values_debounced <- debounce(values_raw, millis = debounce_ms)
-    
+
     rows <- reactive(values_debounced()$rows)
     cols <- reactive(values_debounced()$cols)
-    
+
+    update_inputs <- function(rows = NULL, cols = NULL) {
+      if (!is.null(rows)) {
+        target <- sanitize(rows, rows_min, rows_max)
+        current <- isolate(rows_raw())
+        if (!is.na(target) && (is.na(current) || !identical(target, current))) {
+          updateNumericInput(session, "rows", value = target)
+        }
+      }
+
+      if (!is.null(cols)) {
+        target <- sanitize(cols, cols_min, cols_max)
+        current <- isolate(cols_raw())
+        if (!is.na(target) && (is.na(current) || !identical(target, current))) {
+          updateNumericInput(session, "cols", value = target)
+        }
+      }
+    }
+
     list(
       rows = rows,
       cols = cols,
-      values = reactive(list(rows = rows(), cols = cols()))
+      values = reactive(list(rows = rows(), cols = cols())),
+      set = update_inputs
     )
   })
 }


### PR DESCRIPTION
## Summary
- add a helper in the grid module to push computed row and column counts into the numeric inputs
- synchronize every grid-using visualization module so the controls show the derived layout when plots render

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132aa7c080832b9ad9faedc56ca954)