### PR TITLE
Revert "Hide pairwise grid controls when only one subplot is available"

### DIFF
--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -15,7 +15,11 @@ pairwise_correlation_visualize_ggpairs_ui <- function(id) {
         "Set the height in pixels for each panel of the correlation matrix."
       ))
     ),
-    uiOutput(ns("grid_controls")),
+    plot_grid_ui(
+      id = ns("plot_grid"),
+      rows_help = "Choose how many rows of panels to use when multiple strata are plotted.",
+      cols_help = "Choose how many columns of panels to use when multiple strata are plotted."
+    ),
     fluidRow(
       column(6, add_color_customization_ui(ns, multi_group = TRUE)),
       column(6, base_size_ui(
@@ -69,19 +73,6 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
     
     base_size <- base_size_server(input = input, default = 11)
     grid_inputs <- plot_grid_server("plot_grid")
-
-    output$grid_controls <- renderUI({
-      info <- plot_info()
-      if (is.null(info) || is.null(info$panels) || info$panels <= 1L) {
-        return(NULL)
-      }
-
-      plot_grid_ui(
-        id = ns("plot_grid"),
-        rows_help = "Choose how many rows of panels to use when multiple strata are plotted.",
-        cols_help = "Choose how many columns of panels to use when multiple strata are plotted."
-      )
-    })
     
     build_ggpairs_plot <- function(data, color_value, title = NULL, base_size_value = 11) {
       validate(need(is.data.frame(data) && nrow(data) > 0, "No data available for plotting."))


### PR DESCRIPTION
Reverts nicola-palmieri/TableAnalyzer#213