### PR TITLE
Prevent verbatim outputs from wrapping on deployed app

### DIFF
--- a/app.R
+++ b/app.R
@@ -69,6 +69,12 @@ ui <- navbarPage(
         margin-bottom: 0;
         color: #6c757d;
       }
+      pre.shiny-text-output {
+        white-space: pre;
+        overflow-x: auto;
+        font-family: "Fira Mono", "Source Code Pro", Monaco, monospace;
+        font-size: 0.9rem;
+      }
     "))
   ),
 


### PR DESCRIPTION
## Summary
- override the global styling for `pre.shiny-text-output` to preserve full-width verbatim blocks
- add horizontal scrolling so long skimr summaries render cleanly on shinyapps.io

## Testing
- `Rscript -e "testthat::test_dir('tests')"` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691331fc28d8832bbfe5b62353326d58)