### PR TITLE
Align color customization order in correlation and PCA visuals

### DIFF
--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -79,13 +79,21 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       info$factors$factor2
     })
     
+    factor2_levels <- reactive({
+      info <- model_info()
+      if (is.null(info) || is.null(info$orders)) return(NULL)
+      order2 <- info$orders$order2
+      if (is.null(order2)) NULL else order2
+    })
+
     custom_colors <- add_color_customization_server(
       ns = ns,
       input = input,
       output = output,
       data = df,
       color_var_reactive = color_var_reactive,
-      multi_group = TRUE
+      multi_group = TRUE,
+      level_order_reactive = factor2_levels
     )
     
     base_size <- base_size_server(input = input, default = 13)

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -62,13 +62,30 @@ pairwise_correlation_visualize_ggpairs_server <- function(id, filtered_data, cor
       group_var
     })
     
+    strata_level_order <- reactive({
+      info <- correlation_info()
+      if (is.null(info) || is.null(info$strata_order)) {
+        return(NULL)
+      }
+
+      order_values <- resolve_reactive(info$strata_order)
+      if (is.null(order_values)) {
+        return(NULL)
+      }
+
+      order_values <- as.character(order_values)
+      order_values <- order_values[!is.na(order_values) & nzchar(order_values)]
+      if (!length(order_values)) NULL else order_values
+    })
+
     custom_colors <- add_color_customization_server(
       ns = ns,
       input = input,
       output = output,
       data = filtered_data,
       color_var_reactive = color_var_reactive,
-      multi_group = TRUE
+      multi_group = TRUE,
+      level_order_reactive = strata_level_order
     )
     
     base_size <- base_size_server(input = input, default = 11)

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -228,13 +228,37 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
 
     color_var_reactive <- reactive(valid_column(input$pca_color))
 
+    color_level_order <- reactive({
+      var <- color_var_reactive()
+      if (is.null(var)) {
+        return(NULL)
+      }
+
+      data <- color_data()
+      if (is.null(data) || !is.data.frame(data) || !var %in% names(data)) {
+        return(NULL)
+      }
+
+      column <- data[[var]]
+      levels_vec <- if (is.factor(column)) {
+        levels(base::droplevels(column))
+      } else {
+        unique(as.character(column[!is.na(column)]))
+      }
+
+      levels_vec <- as.character(levels_vec)
+      levels_vec <- levels_vec[!is.na(levels_vec) & nzchar(levels_vec)]
+      if (!length(levels_vec)) NULL else levels_vec
+    })
+
     custom_colors <- add_color_customization_server(
       ns = ns,
       input = input,
       output = output,
       data = color_data,
       color_var_reactive = color_var_reactive,
-      multi_group = TRUE
+      multi_group = TRUE,
+      level_order_reactive = color_level_order
     )
 
     base_size <- base_size_server(


### PR DESCRIPTION
## Summary
- pass the stratification level order from pairwise correlation results into the color customization module so color pickers reflect the plotted strata order
- ensure the PCA visualization shares its color level order with the customization widget so picker order matches the legend

## Testing
- not run (UI change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133bfdb540832bbc3b86f4b19f4c14)