### PR TITLE
Hide upload input for example dataset

### DIFF
--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -24,14 +24,7 @@ upload_ui <- function(id) {
         "Decide whether to explore the built-in example data or load your own table."
       ),
       uiOutput(ns("layout_example")),
-      with_help_tooltip(
-        fileInput(
-          ns("file"),
-          "Upload Excel file (.xlsx / .xls / .xlsm)",
-          accept = c(".xlsx", ".xls", ".xlsm")
-        ),
-        "Provide the Excel workbook that stores your study measurements."
-      ),
+      uiOutput(ns("file_input")),
       uiOutput(ns("sheet_selector")),
       uiOutput(ns("type_selectors"))
     ),
@@ -113,6 +106,22 @@ upload_server <- function(id) {
         render_validation("Please upload an Excel file.")
       }
     }, ignoreInit = FALSE)
+
+    output$file_input <- renderUI({
+      req(input$data_source)
+      if (input$data_source == "example") {
+        return(NULL)
+      }
+
+      with_help_tooltip(
+        fileInput(
+          ns("file"),
+          "Upload Excel file (.xlsx / .xls / .xlsm)",
+          accept = c(".xlsx", ".xls", ".xlsm")
+        ),
+        "Provide the Excel workbook that stores your study measurements."
+      )
+    })
     
     # -----------------------------------------------------------
     # 2️⃣ Example layout preview


### PR DESCRIPTION
## Summary
- replace the always-visible upload control with a dynamic UI output
- render the upload widget only when the user selects either long or wide data sources so that it disappears when the example dataset is chosen

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a5215b04832bbe87d2d32c9594d1)