### PR TITLE
Reorder ANOVA grid controls under subplot sizing

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -22,7 +22,6 @@ visualize_oneway_ui <- function(id) {
         ),
         "Pick the chart style you prefer for comparing group means and error bars."
       ),
-      uiOutput(ns("layout_controls")),
       conditionalPanel(
         condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
         with_help_tooltip(
@@ -65,6 +64,7 @@ visualize_oneway_ui <- function(id) {
           "Adjust how tall each subplot should be in pixels."
         ))
       ),
+      uiOutput(ns("layout_controls")),
       fluidRow(
         column(6, add_color_customization_ui(ns, multi_group = FALSE)),
         column(6, base_size_ui(

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -22,7 +22,6 @@ visualize_twoway_ui <- function(id) {
         ),
         "Pick the chart style you prefer for viewing group means and uncertainty."
       ),
-      uiOutput(ns("layout_controls")),
       conditionalPanel(
         condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
         with_help_tooltip(
@@ -73,6 +72,7 @@ visualize_twoway_ui <- function(id) {
           "Set how tall each subplot should be in pixels."
         ))
       ),
+      uiOutput(ns("layout_controls")),
       fluidRow(
         column(6, add_color_customization_ui(ns, multi_group = TRUE)),
         column(6, base_size_ui(


### PR DESCRIPTION
## Summary
- move the layout grid control group below the subplot width/height pickers in both ANOVA visualization sidebars so that the sizing inputs appear first

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b088d1f8832b877b64e308d5ed59)