### PR TITLE
Prevent crashes when responses are converted to categorical

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -76,11 +76,14 @@ one_way_anova_server <- function(id, filtered_data) {
     })
     
     models <- eventReactive(input$run, {
-      req(filtered_data(), input$group, input$order)
-      validate(need(length(responses()) > 0, "Select at least one response variable."))
+      df <- filtered_data()
+      req(df, input$group, input$order)
+      resp_vals <- responses()
+      validate(need(length(resp_vals) > 0, "Select at least one response variable."))
+      validate_numeric_columns(df, resp_vals, "response variables")
       prepare_stratified_anova(
-        df = filtered_data(),
-        responses = responses(),
+        df = df,
+        responses = resp_vals,
         model = "oneway_anova",
         factor1_var = input$group,
         factor1_order = input$order,

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -104,15 +104,17 @@ two_way_anova_server <- function(id, filtered_data) {
     # Model fitting (via shared helper)
     # -----------------------------------------------------------
     models <- eventReactive(input$run, {
-      req(filtered_data(), input$factor1, input$order1, input$factor2, input$order2)
+      df <- filtered_data()
+      req(df, input$factor1, input$order1, input$factor2, input$order2)
       resp_vals <- responses()
       validate(
         need(length(resp_vals) > 0, "Please select at least one response variable."),
-        need(all(input$order1 %in% unique(filtered_data()[[input$factor1]])), "Invalid level order for first factor."),
-        need(all(input$order2 %in% unique(filtered_data()[[input$factor2]])), "Invalid level order for second factor.")
+        need(all(input$order1 %in% unique(df[[input$factor1]])), "Invalid level order for first factor."),
+        need(all(input$order2 %in% unique(df[[input$factor2]])), "Invalid level order for second factor.")
       )
+      validate_numeric_columns(df, resp_vals, "response variables")
       prepare_stratified_anova(
-        df = filtered_data(),
+        df = df,
         responses = resp_vals,
         model = "twoway_anova",
         factor1_var = input$factor1,

--- a/R/helpers_errors.R
+++ b/R/helpers_errors.R
@@ -25,3 +25,34 @@ format_safe_error_message <- function(title, details = NULL) {
 
   paste0(title, ":\n", paste(details, collapse = "\n"))
 }
+
+validate_numeric_columns <- function(data, columns, context_label = "response variables") {
+  if (is.null(data) || !is.data.frame(data) || length(columns) == 0) {
+    return(invisible(TRUE))
+  }
+
+  missing_cols <- setdiff(columns, names(data))
+  if (length(missing_cols) > 0) {
+    shiny::validate(shiny::need(
+      FALSE,
+      sprintf(
+        "The following columns are no longer available: %s.",
+        paste(missing_cols, collapse = ", ")
+      )
+    ))
+  }
+
+  non_numeric <- columns[!vapply(columns, function(col) is.numeric(data[[col]]), logical(1))]
+  if (length(non_numeric) > 0) {
+    shiny::validate(shiny::need(
+      FALSE,
+      sprintf(
+        "The selected %s must be numeric. Please check their type in the Upload tab: %s.",
+        context_label,
+        paste(non_numeric, collapse = ", ")
+      )
+    ))
+  }
+
+  invisible(TRUE)
+}

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -489,6 +489,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       df <- data()
       responses <- selected_responses()
       req(length(responses) > 0)
+      validate_numeric_columns(df, responses, "response variable(s)")
 
       rhs <- reg_compose_rhs(
         input$fixed,


### PR DESCRIPTION
## Summary
- add a reusable helper to ensure selected response columns are still numeric before modeling
- guard the one-way ANOVA, two-way ANOVA, and regression modules with the new validation so that downstream code never receives factors where numeric data are required

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c002bec0832b9e4147e7bfc075ca)