### PR TITLE
Add shared legend option for two-way ANOVA line plots

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -875,7 +875,8 @@ apply_anova_factor_levels <- function(stats_df, factor1, factor2, order1, order2
 finalize_anova_plot_result <- function(response_plots,
                                        context,
                                        strata_panel_count,
-                                       collect_guides = FALSE) {
+                                       collect_guides = FALSE,
+                                       legend_position = NULL) {
   if (length(response_plots) == 0) {
     return(NULL)
   }
@@ -925,17 +926,22 @@ finalize_anova_plot_result <- function(response_plots,
   if (is.null(warning_text)) {
     if (length(response_plots) == 1) {
       final_plot <- response_plots[[1]]
+      if (collect_guides && !is.null(legend_position)) {
+        final_plot <- final_plot & theme(legend.position = legend_position)
+      }
     } else {
       combined <- patchwork::wrap_plots(
         plotlist = response_plots,
         nrow = response_layout$nrow,
         ncol = response_layout$ncol
       )
-      final_plot <- if (collect_guides) {
-        combined & patchwork::plot_layout(guides = "collect")
-      } else {
-        combined
+      if (collect_guides) {
+        combined <- combined & patchwork::plot_layout(guides = "collect")
+        if (!is.null(legend_position)) {
+          combined <- combined & theme(legend.position = legend_position)
+        }
       }
+      final_plot <- combined
     }
   }
 
@@ -1195,11 +1201,20 @@ plot_anova_lineplot_meanse <- function(data,
                                        show_lines = FALSE,
                                        show_jitter = FALSE,
                                        use_dodge = FALSE,
-                                       share_y_axis = FALSE) {
+                                       share_y_axis = FALSE,
+                                       common_legend = FALSE,
+                                       legend_position = NULL) {
   context <- initialize_anova_plot_context(data, info, layout_values)
   data <- context$data
   factor1 <- context$factor1
   factor2 <- context$factor2
+
+  allowed_positions <- c("bottom", "top", "left", "right")
+  legend_position_value <- if (!is.null(legend_position) && legend_position %in% allowed_positions) {
+    legend_position
+  } else {
+    "bottom"
+  }
 
   shared_y_limits <- if (isTRUE(share_y_axis)) {
     compute_lineplot_shared_limits(context, data, factor1, factor2)
@@ -1273,6 +1288,10 @@ plot_anova_lineplot_meanse <- function(data,
         ncol = current_layout$ncol
       )
 
+      if (isTRUE(common_legend)) {
+        combined <- combined & patchwork::plot_layout(guides = "collect")
+      }
+
       title_plot <- ggplot() +
         theme_void() +
         ggtitle(resp) +
@@ -1322,7 +1341,8 @@ plot_anova_lineplot_meanse <- function(data,
     response_plots = response_plots,
     context = context,
     strata_panel_count = strata_panel_count,
-    collect_guides = TRUE
+    collect_guides = isTRUE(common_legend),
+    legend_position = if (isTRUE(common_legend)) legend_position_value else NULL
   )
 }
 

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -83,10 +83,13 @@ visualize_twoway_ui <- function(id) {
       uiOutput(ns("layout_controls")),
       fluidRow(
         column(6, add_color_customization_ui(ns, multi_group = TRUE)),
-        column(6, base_size_ui(
-          ns,
-          default = 13,
-          help_text = "Adjust the base font size used for the ANOVA plots."
+        column(6, tagList(
+          base_size_ui(
+            ns,
+            default = 13,
+            help_text = "Adjust the base font size used for the ANOVA plots."
+          ),
+          uiOutput(ns("common_legend_controls"))
         ))
       ),
       br(),
@@ -141,10 +144,72 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     base_size <- base_size_server(input, default = 13)
     strata_grid <- plot_grid_server("strata_grid")
     response_grid <- plot_grid_server("response_grid")
-    
+
     active <- reactive(TRUE)
-    
+
+    common_legend_available <- reactive({
+      info <- model_info()
+      if (is.null(info)) {
+        return(FALSE)
+      }
+      has_multiple_responses <- length(info$responses %||% character()) > 1
+      has_strata <- !is.null(info$strata) && !is.null(info$strata$var)
+      has_multiple_responses || has_strata
+    })
+
+    output$common_legend_controls <- renderUI({
+      if (!isTRUE(common_legend_available()) || input$plot_type != "lineplot_mean_se") {
+        return(NULL)
+      }
+
+      checkbox <- div(
+        class = "mt-3",
+        with_help_tooltip(
+          checkboxInput(
+            ns("use_common_legend"),
+            "Use common legend",
+            value = FALSE
+          ),
+          "Merge the legends across responses or strata into a single shared legend."
+        )
+      )
+
+      legend_position <- if (isTRUE(input$use_common_legend)) {
+        div(
+          class = "mt-2",
+          with_help_tooltip(
+            selectInput(
+              ns("common_legend_position"),
+              "Legend position",
+              choices = c(
+                "Bottom" = "bottom",
+                "Right" = "right",
+                "Top" = "top",
+                "Left" = "left"
+              ),
+              selected = input$common_legend_position %||% "bottom"
+            ),
+            "Choose where the combined legend should be displayed."
+          )
+        )
+      } else {
+        NULL
+      }
+
+      tagList(checkbox, legend_position)
+    })
+
     state <- reactive({
+      use_common_legend <- isTRUE(common_legend_available()) &&
+        input$plot_type == "lineplot_mean_se" &&
+        isTRUE(input$use_common_legend)
+      legend_pos <- input$common_legend_position
+      valid_positions <- c("bottom", "top", "left", "right")
+      resolved_position <- if (!is.null(legend_pos) && legend_pos %in% valid_positions) {
+        legend_pos
+      } else {
+        "bottom"
+      }
       list(
         data        = df(),
         info        = model_info(),
@@ -159,7 +224,9 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
         use_dodge     = isTRUE(input$lineplot_use_dodge),
         show_jitter   = isTRUE(input$lineplot_show_jitter),
         plot_type     = input$plot_type,
-        share_y_axis  = isTRUE(input$share_y_axis)
+        share_y_axis  = isTRUE(input$share_y_axis),
+        common_legend = use_common_legend,
+        legend_position = if (use_common_legend) resolved_position else NULL
       )
     })
 
@@ -172,7 +239,9 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
                                   show_lines,
                                   show_jitter,
                                   use_dodge,
-                                  share_y_axis) {
+                                  share_y_axis,
+                                  common_legend = FALSE,
+                                  legend_position = NULL) {
       if (is.null(info) || !identical(info$type, "twoway_anova") || is.null(data) || nrow(data) == 0) {
         return(list(
           lineplot_mean_se = list(plot = NULL, warning = "No data or results available.", layout = NULL),
@@ -220,7 +289,9 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
           show_lines = show_lines,
           show_jitter = show_jitter,
           use_dodge = use_dodge,
-          share_y_axis = share_y_axis
+          share_y_axis = share_y_axis,
+          common_legend = common_legend,
+          legend_position = legend_position
         ),
         barplot_mean_se = plot_anova_barplot_meanse(
           data, info, layout_values = layout_inputs,
@@ -249,7 +320,9 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
         s$show_lines,
         s$show_jitter,
         s$use_dodge,
-        s$share_y_axis
+        s$share_y_axis,
+        s$common_legend,
+        s$legend_position
       )
       res[[if (!is.null(s$plot_type) && s$plot_type %in% names(res)) s$plot_type else "lineplot_mean_se"]]
     })
@@ -281,6 +354,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
         s$resp_rows,
         s$resp_cols,
         s$share_y_axis,
+        s$common_legend,
+        s$legend_position %||% "none",
         sep = "_"
       )
       if (!identical(key, cached_key())) {


### PR DESCRIPTION
## Summary
- add UI controls in the two-way ANOVA visualizer to enable a common legend (with position selection) when multiple responses or strata are shown
- pass the new options through the plotting state/cache so that they only affect lineplots and respect availability conditions
- update the shared line-plot helper to truly collect patchwork legends and honor the chosen placement when a common legend is requested

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dadf72b0832bb98e3666f9ca6a3a)