### PR TITLE
Enable shared common legend for two-way ANOVA barplots

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1925,11 +1925,20 @@ plot_anova_barplot_meanse <- function(data,
                                       show_value_labels = FALSE,
                                       base_size = 14,
                                       posthoc_all = NULL,
-                                      share_y_axis = FALSE) {
+                                      share_y_axis = FALSE,
+                                      common_legend = FALSE,
+                                      legend_position = NULL) {
   context <- initialize_anova_plot_context(data, info, layout_values)
   data <- context$data
   factor1 <- context$factor1
   factor2 <- context$factor2
+
+  allowed_positions <- c("bottom", "top", "left", "right")
+  legend_position_value <- if (!is.null(legend_position) && legend_position %in% allowed_positions) {
+    legend_position
+  } else {
+    "bottom"
+  }
 
   if (is.null(factor1) || length(context$responses) == 0) {
     return(NULL)
@@ -2031,7 +2040,8 @@ plot_anova_barplot_meanse <- function(data,
     response_plots = response_plots,
     context = context,
     strata_panel_count = strata_panel_count,
-    collect_guides = FALSE
+    collect_guides = isTRUE(common_legend),
+    legend_position = if (isTRUE(common_legend)) legend_position_value else NULL
   )
 }
 

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -179,7 +179,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     })
 
     output$common_legend_controls <- renderUI({
-      if (!isTRUE(common_legend_available()) || input$plot_type != "lineplot_mean_se") {
+      legend_supported <- input$plot_type %in% c("lineplot_mean_se", "barplot_mean_se")
+      if (!isTRUE(common_legend_available()) || !legend_supported) {
         return(NULL)
       }
 
@@ -221,8 +222,9 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     })
 
     state <- reactive({
+      legend_supported <- input$plot_type %in% c("lineplot_mean_se", "barplot_mean_se")
       use_common_legend <- isTRUE(common_legend_available()) &&
-        input$plot_type == "lineplot_mean_se" &&
+        legend_supported &&
         isTRUE(legend_state$enabled)
       legend_pos <- legend_state$position
       valid_positions <- c("bottom", "top", "left", "right")
@@ -320,7 +322,9 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
           show_value_labels = show_labels,
           base_size = base_size_value,
           posthoc_all = info$posthoc,
-          share_y_axis = share_y_axis
+          share_y_axis = share_y_axis,
+          common_legend = common_legend,
+          legend_position = legend_position
         )
       )
     }


### PR DESCRIPTION
## Summary
- expose the common legend controls for both line and bar visualizations in the two-way ANOVA module
- extend the bar plot renderer to accept the shared legend configuration and forward it to the patchwork layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e95ebfc8832ba1a20a9870ef8b1a)