### PR TITLE
Standardize order of levels widgets

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -62,7 +62,7 @@ one_way_anova_server <- function(id, filtered_data) {
     
     output$level_order <- renderUI({
       req(filtered_data(), input$group)
-      levels <- unique(as.character(filtered_data()[[input$group]]))
+      levels <- resolve_order_levels(filtered_data()[[input$group]])
       with_help_tooltip(
         selectInput(
           ns("order"),

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -72,7 +72,7 @@ two_way_anova_server <- function(id, filtered_data) {
     # -----------------------------------------------------------
     output$level_order_1 <- renderUI({
       req(filtered_data(), input$factor1)
-      levels1 <- unique(as.character(filtered_data()[[input$factor1]]))
+      levels1 <- resolve_order_levels(filtered_data()[[input$factor1]])
       with_help_tooltip(
         selectInput(
           ns("order1"),
@@ -87,7 +87,7 @@ two_way_anova_server <- function(id, filtered_data) {
     
     output$level_order_2 <- renderUI({
       req(filtered_data(), input$factor2)
-      levels2 <- unique(as.character(filtered_data()[[input$factor2]]))
+      levels2 <- resolve_order_levels(filtered_data()[[input$factor2]])
       with_help_tooltip(
         selectInput(
           ns("order2"),

--- a/R/helpers_levels.R
+++ b/R/helpers_levels.R
@@ -1,0 +1,27 @@
+# ===============================================================
+# 🔧 Helpers for level-order widgets used across the app
+# ===============================================================
+
+#' Collect the available levels for an "order of levels" widget.
+#'
+#' This helper centralizes the logic that was previously duplicated
+#' across LM, LMM, ANOVA, and stratification modules. In every case we
+#' want the behaviour to match the regression modules: factor levels are
+#' shown as-is, while character vectors drop `NA`s before taking the
+#' unique values.
+#'
+#' @param values A vector (factor or character) containing the candidate
+#'   levels.
+#'
+#' @return A character vector of unique levels suitable for a selectInput.
+resolve_order_levels <- function(values) {
+  if (is.null(values)) return(character())
+
+  if (is.factor(values)) {
+    levels(values)
+  } else {
+    values <- values[!is.na(values)]
+    unique(as.character(values))
+  }
+}
+

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -416,11 +416,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       tagList(
         lapply(fac_vars, function(var) {
           values <- df[[var]]
-          if (is.factor(values)) lvls <- levels(values)
-          else {
-            values <- values[!is.na(values)]
-            lvls <- unique(as.character(values))
-          }
+          lvls <- resolve_order_levels(values)
           with_help_tooltip(
             selectInput(
               ns(paste0("order_", var)),

--- a/R/submodule_stratification.R
+++ b/R/submodule_stratification.R
@@ -52,9 +52,7 @@ stratification_server <- function(id, data) {
       d <- req(df())
       
       values <- d[[input$stratify_var]]
-      values <- values[!is.na(values)]
-      available_levels <- if (is.factor(values)) levels(values) else unique(as.character(values))
-      available_levels <- available_levels[nzchar(available_levels)]
+      available_levels <- resolve_order_levels(values)
       
       n_levels <- length(available_levels)
       validate(need(n_levels <= MAX_STRATIFICATION_LEVELS,


### PR DESCRIPTION
## Summary
- add a shared helper that mirrors the LM/LMM behaviour for computing available levels
- use the helper in the one-way/two-way ANOVA modules so NA values are consistently excluded
- wire stratification and regression modules through the helper so all level-order widgets stay in sync

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f395d378832b808d50fee1757642)