### PR TITLE
Add shared legend option to descriptive plots

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -30,10 +30,13 @@ visualize_categorical_barplots_ui <- function(id) {
     ),
     fluidRow(
       column(6, add_color_customization_ui(ns, multi_group = TRUE)),
-      column(6, base_size_ui(
-        ns,
-        default = 13,
-        help_text = "Adjust the base font size used for barplot text elements."
+      column(6, tagList(
+        base_size_ui(
+          ns,
+          default = 13,
+          help_text = "Adjust the base font size used for barplot text elements."
+        ),
+        uiOutput(ns("common_legend_controls"))
       ))
     ),
     hr(),
@@ -85,7 +88,30 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       ns, input, output, filtered_data, color_var, multi_group = TRUE
     )
     
+    legend_state <- reactiveValues(
+      enabled = FALSE,
+      position = "bottom"
+    )
+
+    observeEvent(input$use_common_legend, {
+      req(!is.null(input$use_common_legend))
+      legend_state$enabled <- isTRUE(input$use_common_legend)
+    }, ignoreNULL = TRUE)
+
+    observeEvent(input$common_legend_position, {
+      req(!is.null(input$common_legend_position))
+      legend_state$position <- input$common_legend_position
+    }, ignoreNULL = TRUE)
+
     state <- reactive({
+      legend_allowed <- !is.null(color_var())
+      valid_positions <- c("bottom", "top", "left", "right")
+      resolved_position <- if (!is.null(legend_state$position) && legend_state$position %in% valid_positions) {
+        legend_state$position
+      } else {
+        "bottom"
+      }
+      use_common_legend <- legend_allowed && isTRUE(legend_state$enabled)
       list(
         info = summary_info(),
         dat = filtered_data(),
@@ -94,7 +120,9 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         colors = custom_colors(),
         base_size = base_size(),
         rows = grid$rows(),
-        cols = grid$cols()
+        cols = grid$cols(),
+        common_legend = use_common_legend,
+        legend_position = if (use_common_legend) resolved_position else NULL
       )
     })
     
@@ -116,8 +144,66 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         nrow_input = s$rows,
         ncol_input = s$cols,
         fill_colors = s$colors,
-        base_size = s$base_size
+        base_size = s$base_size,
+        common_legend = s$common_legend,
+        legend_position = s$legend_position
       )
+    })
+
+    common_legend_available <- reactive({
+      req(active())
+      info <- plot_info()
+      has_group <- !is.null(color_var())
+      n_panels <- info$panels %||% 0L
+      has_group && n_panels > 1L
+    })
+
+    observeEvent(common_legend_available(), {
+      if (!isTRUE(common_legend_available())) {
+        legend_state$enabled <- FALSE
+      }
+    })
+
+    output$common_legend_controls <- renderUI({
+      if (!isTRUE(common_legend_available())) {
+        return(NULL)
+      }
+
+      checkbox <- div(
+        class = "mt-3",
+        with_help_tooltip(
+          checkboxInput(
+            ns("use_common_legend"),
+            "Use common legend",
+            value = isTRUE(legend_state$enabled)
+          ),
+          "Merge legends across the categorical barplots into a single shared legend."
+        )
+      )
+
+      legend_position <- if (isTRUE(legend_state$enabled)) {
+        div(
+          class = "mt-2",
+          with_help_tooltip(
+            selectInput(
+              ns("common_legend_position"),
+              "Legend position",
+              choices = c(
+                "Bottom" = "bottom",
+                "Right" = "right",
+                "Top" = "top",
+                "Left" = "left"
+              ),
+              selected = legend_state$position %||% "bottom"
+            ),
+            "Choose where the combined legend should be displayed."
+          )
+        )
+      } else {
+        NULL
+      }
+
+      tagList(checkbox, legend_position)
     })
     
     plot_dimensions <- reactive({
@@ -168,8 +254,10 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         s$labels,
         s$colors,
         s$base_size,
-        s$rows,          
-        s$cols,          
+        s$rows,
+        s$cols,
+        s$common_legend,
+        s$legend_position %||% "",
         sep = "_"
       )
       if (!identical(key, cached_key())) {
@@ -262,7 +350,9 @@ build_descriptive_categorical_plot <- function(df,
                                                ncol_input = NULL,
                                                fill_colors = NULL,
                                                show_value_labels = FALSE,
-                                               base_size = 13) {
+                                               base_size = 13,
+                                               common_legend = FALSE,
+                                               legend_position = NULL) {
   if (is.null(df) || !is.data.frame(df) || nrow(df) == 0) return(NULL)
   
   factor_vars <- names(df)[vapply(df, function(x) {
@@ -397,6 +487,12 @@ build_descriptive_categorical_plot <- function(df,
       patchwork::plot_annotation(
         theme = theme(plot.title = element_text(size = 16, face = "bold"))
       )
+
+    combined <- apply_common_legend_layout(
+      combined,
+      legend_position = legend_position,
+      collect_guides = isTRUE(common_legend)
+    )
   }
 
   list(


### PR DESCRIPTION
## Summary
- add common legend controls to the categorical barplot, numeric boxplot, and numeric histogram visualizations
- enable shared legend collection and positioning when multiple grouped subplots are displayed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915f7030f64832bb2d81a35919cf72f)