### PR TITLE
Fix pairwise scatterplot matrix visualization handle

### DIFF
--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -278,8 +278,18 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         )
       }
     )
-    
+
     outputOptions(output, "plot", suspendWhenHidden = TRUE)
+
+    list(
+      warning = reactive({
+        info <- plot_info()
+        if (is.null(info)) NULL else info$warning
+      }),
+      plot = reactive(cached_plot()),
+      width = reactive(plot_dimensions()$width),
+      height = reactive(plot_dimensions()$height)
+    )
   })
 }
 


### PR DESCRIPTION
## Summary
- return reactive plot, sizing, and warning handles from the GGPairs visualization module
- ensure the pairwise scatterplot matrix output can be rendered and downloaded again

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0e9cc4a4832bb3989d56207fd350)