### PR TITLE
Add tests for upload and regression helpers

### DIFF
--- a/tests/test_regression_shared.R
+++ b/tests/test_regression_shared.R
@@ -1,0 +1,50 @@
+library(testthat)
+source("R/regression_analysis_shared.R")
+
+test_that("reg_detect_types identifies numeric and categorical variables across ranges", {
+  df <- data.frame(
+    response = c(-1e308, 0, 1e308),
+    group = factor(c("a", "b", "a")),
+    label = c("x", "y", "z"),
+    stringsAsFactors = FALSE
+  )
+
+  types <- reg_detect_types(df)
+
+  expect_setequal(types$num, "response")
+  expect_setequal(types$fac, c("group", "label"))
+})
+
+
+test_that("reg_compose_rhs builds correct formula parts for lm and lmm", {
+  fixed <- c("group", "treatment")
+  covar <- "age"
+  interactions <- "group:treatment"
+
+  expect_equal(
+    reg_compose_rhs(fixed, covar, interactions, random = NULL, engine = "lm"),
+    c(fixed, covar, interactions)
+  )
+
+  expect_equal(
+    reg_compose_rhs(fixed, covar, interactions, random = "site", engine = "lmm"),
+    c(fixed, covar, interactions, "(1|site)")
+  )
+})
+
+
+test_that("tidy_regression_model returns metrics and coefficients for lm", {
+  df <- data.frame(
+    y = c(1, 2, 3, 4),
+    x = c(0, 1, 0, 1)
+  )
+
+  model <- lm(y ~ x, data = df)
+  tidy <- tidy_regression_model(model, engine = "lm")
+
+  expect_true("summary" %in% names(tidy))
+  expect_true("effects" %in% names(tidy))
+  expect_s3_class(tidy$summary, "data.frame")
+  expect_true(all(c("metric", "value") %in% names(tidy$effects$metrics)))
+  expect_true("Effect" %in% names(tidy$effects$anova))
+})

--- a/tests/test_upload_validation.R
+++ b/tests/test_upload_validation.R
@@ -1,0 +1,69 @@
+library(testthat)
+library(openxlsx)
+source("R/module_upload_helpers.R")
+
+make_workbook <- function(matrix_rows) {
+  path <- tempfile(fileext = ".xlsx")
+  openxlsx::write.xlsx(matrix_rows, path, colNames = FALSE)
+  path
+}
+
+test_that("convert_wide_to_long reshapes wide data and preserves NA", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R2"),
+    c("1", "A", "1.5", "2.5"),
+    c("2", "B", "3.0", NA)
+  ))
+
+  result <- convert_wide_to_long(path)
+
+  expect_s3_class(result, "tbl_df")
+  expect_equal(sort(names(result)), sort(c("Sample", "Group", "Replicate", "Measurement")))
+  expect_equal(nrow(result), 4)
+  expect_true(any(is.na(result$Measurement)))
+  expect_equal(result$Measurement[result$Sample == "1" & result$Replicate == "R1"], 1.5)
+})
+
+test_that("convert_wide_to_long detects duplicate measurements per replicate", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R2"),
+    c("1", "A", "3", "4"),
+    c("1", "A", "5", "6")
+  ))
+
+  expect_error(convert_wide_to_long(path), "Duplicate measurements detected")
+})
+
+test_that("convert_wide_to_long tolerates extra header rows and empty cells", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R2"),
+    c("Notes", "Ignore", "", ""),
+    c("3", "C", "7.5", "8.5")
+  ))
+
+  result <- convert_wide_to_long(path)
+
+  expect_equal(nrow(result), 4)
+  expect_true(any(is.na(result$Measurement)))
+  expect_true(all(result$Replicate %in% c("R1", "R2")))
+})
+
+
+test_that("preprocess_uploaded_table orders factors numerically and keeps NAs", {
+  df <- data.frame(
+    sample_id = 1:4,
+    treatment = c("T2", "T10", "T1", NA),
+    batch = rep("Only", 4),
+    stringsAsFactors = FALSE
+  )
+
+  processed <- preprocess_uploaded_table(df)
+
+  expect_s3_class(processed$treatment, "factor")
+  expect_equal(levels(processed$treatment), c("T1", "T2", "T10"))
+  expect_true(any(is.na(processed$treatment)))
+  expect_equal(levels(processed$batch), "Only")
+})


### PR DESCRIPTION
## Summary
- add testthat coverage for upload helpers including wide-to-long reshaping, duplicate detection, and factor cleaning
- add regression helper tests for type detection, formula composition, and tidy summaries

## Testing
- Rscript -e "testthat::test_dir('tests')" (fails: Rscript command not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b24565084832b9fba1fc504d8cd0d)