### PR TITLE
Add comprehensive helper tests

### DIFF
--- a/tests/test_anova_shared.R
+++ b/tests/test_anova_shared.R
@@ -1,0 +1,42 @@
+library(testthat)
+library(dplyr)
+source(testthat::test_path("..", "R", "anova_shared.R"))
+
+
+test_that("prepare_stratified_anova sets factor levels and handles single strata", {
+  df <- data.frame(
+    response = c(1, 2, 3, 4),
+    group = c("High", "High", "Low", "Low"),
+    strata = rep("S1", 4),
+    stringsAsFactors = FALSE
+  )
+
+  prep <- prepare_stratified_anova(
+    df,
+    responses = "response",
+    model = "oneway_anova",
+    factor1_var = "group",
+    factor1_order = c("Low", "High"),
+    stratification = list(var = "strata", levels = "S1")
+  )
+
+  expect_equal(levels(prep$data_used$group), c("Low", "High"))
+  expect_equal(prep$strata$levels, "S1")
+  expect_true(all(names(prep$models) %in% c("S1")))
+})
+
+
+test_that("prepare_anova_outputs returns rounded tables", {
+  df <- data.frame(
+    response = c(1, 2, 1.5, 2.5),
+    group = factor(c("A", "A", "B", "B"))
+  )
+
+  model <- aov(response ~ group, data = df)
+  outputs <- prepare_anova_outputs(model, factor_names = "group")
+
+  expect_s3_class(outputs$anova_table, "data.frame")
+  expect_true("p.value" %in% names(outputs$anova_table))
+  expect_true(is.numeric(outputs$anova_table$p.value))
+  expect_true(all(!is.na(outputs$anova_significant)))
+})

--- a/tests/test_convert_wide_to_long.R
+++ b/tests/test_convert_wide_to_long.R
@@ -1,210 +1,52 @@
+library(testthat)
 library(openxlsx)
-library(dplyr)
-library(readxl)
-library(tidyr)
-library(zoo)
-library(purrr)
+source(testthat::test_path("..", "R", "module_upload_helpers.R"))
 
-# ==========================================================
-# Paste your convert_wide_to_long() and helpers here
-# ==========================================================
-
-convert_wide_to_long <- function(path, sheet = 1, replicate_col = "Replicate") {
-  # ---- Read first two rows to capture merged header structure ----
-  headers <- readxl::read_excel(path, sheet = sheet, n_max = 2, col_names = FALSE)
-  header1 <- as.character(unlist(headers[1, , drop = TRUE]))
-  header2 <- as.character(unlist(headers[2, , drop = TRUE]))
-  
-  # ---- Fill blanks forward in first header ----
-  header1[header1 == ""] <- NA
-  header1 <- zoo::na.locf(header1, na.rm = FALSE)
-  header2[is.na(header2) | header2 == ""] <- ""
-  
-  # ---- Combine headers safely ----
-  clean_names <- ifelse(header2 == "", header1, paste0(header1, "_", header2))
-  clean_names <- make.unique(clean_names, sep = "_")
-  
-  # ---- Detect number of fixed columns ----
-  first_empty <- which(is.na(headers[1, ]) | headers[1, ] == "")[1]
-  if (is.na(first_empty)) {
-    n_fixed <- 0
-  } else {
-    n_fixed <- max(0, first_empty - 2)
-  }
-  fixed_cols <- clean_names[seq_len(n_fixed)]
-  measure_cols <- setdiff(clean_names, fixed_cols)
-  
-  # ---- Read data with computed names ----
-  data <- readxl::read_excel(path, sheet = sheet, skip = 2, col_names = clean_names)
-  
-  # ---- Reshape from wide to long then back to tidy ----
-  data_long <- data |>
-    pivot_longer(
-      cols = tidyselect::all_of(measure_cols),
-      names_to = c("Variable", replicate_col),
-      names_pattern = "^(.*)_([^_]*)$",
-      values_to = "Value"
-    ) |>
-    pivot_wider(names_from = "Variable", values_from = "Value")
-  
-  as_tibble(data_long)
-}
-
-
-# ==========================================================
-# Helper functions
-# ==========================================================
-
-dir.create("test_excels", showWarnings = FALSE)
-
-write_test_excel <- function(data, name, index) {
-  filename <- sprintf("%02d_%s.xlsx", index, name)
-  path <- file.path("test_excels", filename)
-  openxlsx::write.xlsx(data, path, colNames = FALSE)
+make_workbook <- function(matrix_rows) {
+  path <- tempfile(fileext = ".xlsx")
+  openxlsx::write.xlsx(matrix_rows, path, colNames = FALSE)
   path
 }
 
-paths <- purrr::map2(
-  seq_along(tests),
-  tests,
-  function(i, x) write_test_excel(x[[2]], x[[1]], i)
-)
-safe_convert <- safely(function(path) {
-  convert_wide_to_long(path)
-})
-
-
-# ==========================================================
-# Generate 20 Excel scenarios
-# ==========================================================
-
-tests <- list(
-  list("simple_clean", rbind(
-    c("ID", "Group", "A", "B"),
-    c("", "", "Rep1", "Rep2"),
-    c("1", "Ctrl", "5", "6"),
-    c("2", "Treat", "7", "8")
-  )),
-  list("no_second_header", rbind(
-    c("ID", "Group", "A_Rep1", "A_Rep2"),
-    c("", "", "", ""),
-    c("1", "Ctrl", "10", "12")
-  )),
-  list("irregular_merged", rbind(
-    c("ID", "Group", "A", "", "B", ""),
-    c("", "", "Rep1", "Rep2", "Rep1", "Rep2"),
-    c("1", "Ctrl", "1.2", "1.3", "5.1", "5.2")
-  )),
-  list("blank_first_row", rbind(
-    c("", "", "", ""),
-    c("ID", "Group", "A_Rep1", "A_Rep2"),
-    c("1", "Ctrl", "5", "7")
-  )),
-  list("duplicate_subheaders", rbind(
-    c("ID", "Group", "A", "A"),
-    c("", "", "Rep1", "Rep1"),
-    c("1", "Ctrl", "1", "2")
-  )),
-  list("trailing_empty", rbind(
-    c("ID", "Group", "A", "B", ""),
-    c("", "", "Rep1", "Rep2", ""),
-    c("1", "Ctrl", "1", "2", "")
-  )),
-  list("numeric_headers", rbind(
-    c("ID", "Group", "1", "2", "3"),
-    c("", "", "Rep1", "Rep2", "Rep3"),
-    c("1", "Ctrl", "4", "5", "6")
-  )),
-  list("mixed_headers", rbind(
-    c("ID", "Diet", "Day1", "Day2", "3"),
-    c("", "", "R1", "R2", "R3"),
-    c("1", "Low", "1.1", "1.2", "1.3")
-  )),
-  list("spaces_specialchars", rbind(
-    c(" ID ", "Group ", "A (mg)", "B (mg)"),
-    c("", "", "Rep 1", "Rep 2"),
-    c("1", "Ctrl", "7.1", "7.2")
-  )),
-  list("empty_rows_na", rbind(
-    c("ID", "Group", "A", "B"),
-    c("", "", "Rep1", "Rep2"),
-    c("1", "Ctrl", "10", NA),
-    c("", "", "", "")
-  )),
-  list("merged_across_three", rbind(
-    c("ID", "Treatment", "A", "", "", "B", "", ""),
-    c("", "", "R1", "R2", "R3", "R1", "R2", "R3"),
-    c("1", "Low", "1", "2", "3", "4", "5", "6")
-  )),
-  list("all_numeric_header", rbind(
-    c("1", "2", "3", "4"),
-    c("Rep1", "Rep2", "Rep3", "Rep4"),
-    c("5", "6", "7", "8")
-  )),
-  list("underscores_mixed", rbind(
-    c("ID", "Batch", "A_Rep1", "A.Rep2", "A-Rep3"),
-    c("", "", "", "", ""),
-    c("1", "B1", "1", "2", "3")
-  )),
-  list("text_numeric_combo", rbind(
-    c("ID", "Stage", "Day 1", "Day 2", "Day 10"),
-    c("", "", "RepA", "RepB", "RepC"),
-    c("1", "Init", "0.1", "0.2", "0.9")
-  )),
-  list("multi_blank_zones", rbind(
-    c("ID", "", "", "B", "", ""),
-    c("", "", "", "R1", "R2", ""),
-    c("1", "Ctrl", "5", "6", "7", "8")
-  )),
-  list("missing_measure_values", rbind(
-    c("ID", "Group", "A", "B"),
-    c("", "", "Rep1", "Rep2"),
-    c("1", "Ctrl", NA, "5")
-  )),
-  list("special_symbols", rbind(
-    c("Sample#", "Type$", "A%", "B%"),
-    c("", "", "R1", "R2"),
-    c("1", "Ctrl", "2.2", "2.5")
-  )),
-  list("wide_gap_headers", rbind(
-    c("ID", "Group", rep("", 10)),
-    c("", "", paste0("V", 1:10)),
-    c("1", "Ctrl", as.character(1:10))
-  )),
-  list("duplicate_block_headers", rbind(
-    c("ID", "Group", "A", "A", "B", "B"),
-    c("", "", "R1", "R2", "R1", "R2"),
-    c("1", "Ctrl", "1", "2", "3", "4")
-  )),
-  list("weird_chars_and_spaces", rbind(
-    c(" ID ", " T reat ", "A! ", "B? "),
-    c("", "", "R-1", "R-2"),
-    c("1", "Low", "10", "12")
+test_that("convert_wide_to_long handles blank separator columns", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Pad", "", "Measurement", "Measurement"),
+    c("", "", "", "", "R1", "R2"),
+    c("1", "A", "x", "", "5", "6"),
+    c("2", "B", "y", "", "7", "8")
   ))
-)
 
-paths <- sapply(tests, function(x) write_test_excel(x[[2]], x[[1]]))
+  result <- convert_wide_to_long(path)
 
-# ==========================================================
-# Run safely on all files
-# ==========================================================
-
-results <- map(paths, function(p) {
-  message("Testing: ", basename(p))
-  res <- safe_convert(p)
-  tibble(
-    file = basename(p),
-    success = !is.null(res$result),
-    error = if (!is.null(res$error)) conditionMessage(res$error) else NA_character_,
-    rows = if (!is.null(res$result)) nrow(res$result) else NA_integer_,
-    cols = if (!is.null(res$result)) ncol(res$result) else NA_integer_
-  )
+  expect_s3_class(result, "tbl_df")
+  expect_true(all(c("Sample", "Group", "Replicate", "Measurement") %in% names(result)))
+  expect_equal(nrow(result), 4)
+  expect_equal(result$Measurement[result$Sample == "1" & result$Replicate == "R2"], 6)
 })
 
-summary_df <- bind_rows(results)
-print(summary_df)
 
-# Save diagnostics
-write.csv(summary_df, "conversion_summary.csv", row.names = FALSE)
+test_that("convert_wide_to_long flags duplicate measurements per replicate", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R1"),
+    c("1", "A", "3", "4")
+  ))
 
-cat("\nSummary written to conversion_summary.csv\n")
+  expect_error(convert_wide_to_long(path), "Duplicate measurements detected")
+})
+
+
+test_that("convert_wide_to_long tolerates extra header rows and empty trailing columns", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", "Measurement", ""),
+    c("", "", "R1", "R2", ""),
+    c("Notes", "Ignore", "", "", ""),
+    c("3", "C", "7.5", NA, "")
+  ))
+
+  result <- convert_wide_to_long(path)
+
+  expect_equal(nrow(result), 2)
+  expect_true(any(is.na(result$Measurement)))
+  expect_true(all(result$Replicate %in% c("R1", "R2")))
+})

--- a/tests/test_helpers_errors.R
+++ b/tests/test_helpers_errors.R
@@ -1,0 +1,22 @@
+library(testthat)
+source(testthat::test_path("..", "R", "helpers_errors.R"))
+
+
+test_that("format_safe_error_message handles empty titles and list details", {
+  msg <- format_safe_error_message("", list(" Line1 ", "Line2"))
+  expect_equal(msg, "Error:\nLine1\nLine2")
+
+  condition_msg <- format_safe_error_message("Alert", simpleError("failed"))
+  expect_equal(condition_msg, "Alert:\nfailed")
+})
+
+
+test_that("validate_numeric_columns ignores missing inputs and fails on non-numeric", {
+  expect_invisible(validate_numeric_columns(NULL, NULL))
+
+  df <- data.frame(a = 1:3, b = letters[1:3])
+  expect_error(
+    validate_numeric_columns(df, c("a", "b"), context_label = "responses"),
+    "must be numeric"
+  )
+})

--- a/tests/test_regression_shared.R
+++ b/tests/test_regression_shared.R
@@ -1,0 +1,50 @@
+library(testthat)
+source(testthat::test_path("..", "R", "regression_analysis_shared.R"))
+
+test_that("reg_detect_types identifies numeric and categorical variables across ranges", {
+  df <- data.frame(
+    response = c(-1e308, 0, 1e308),
+    group = factor(c("a", "b", "a")),
+    label = c("x", "y", "z"),
+    stringsAsFactors = FALSE
+  )
+
+  types <- reg_detect_types(df)
+
+  expect_setequal(types$num, "response")
+  expect_setequal(types$fac, c("group", "label"))
+})
+
+
+test_that("reg_compose_rhs builds correct formula parts for lm and lmm", {
+  fixed <- c("group", "treatment")
+  covar <- "age"
+  interactions <- "group:treatment"
+
+  expect_equal(
+    reg_compose_rhs(fixed, covar, interactions, random = NULL, engine = "lm"),
+    c(fixed, covar, interactions)
+  )
+
+  expect_equal(
+    reg_compose_rhs(fixed, covar, interactions, random = "site", engine = "lmm"),
+    c(fixed, covar, interactions, "(1|site)")
+  )
+})
+
+
+test_that("tidy_regression_model returns metrics and coefficients for lm", {
+  df <- data.frame(
+    y = c(1, 2, 3, 4),
+    x = c(0, 1, 0, 1)
+  )
+
+  model <- lm(y ~ x, data = df)
+  tidy <- tidy_regression_model(model, engine = "lm")
+
+  expect_true("summary" %in% names(tidy))
+  expect_true("effects" %in% names(tidy))
+  expect_s3_class(tidy$summary, "data.frame")
+  expect_true(all(c("metric", "value") %in% names(tidy$effects$metrics)))
+  expect_true("Effect" %in% names(tidy$effects$anova))
+})

--- a/tests/test_upload_validation.R
+++ b/tests/test_upload_validation.R
@@ -1,0 +1,69 @@
+library(testthat)
+library(openxlsx)
+source(testthat::test_path("..", "R", "module_upload_helpers.R"))
+
+make_workbook <- function(matrix_rows) {
+  path <- tempfile(fileext = ".xlsx")
+  openxlsx::write.xlsx(matrix_rows, path, colNames = FALSE)
+  path
+}
+
+test_that("convert_wide_to_long reshapes wide data and preserves NA", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R2"),
+    c("1", "A", "1.5", "2.5"),
+    c("2", "B", "3.0", NA)
+  ))
+
+  result <- convert_wide_to_long(path)
+
+  expect_s3_class(result, "tbl_df")
+  expect_equal(sort(names(result)), sort(c("Sample", "Group", "Replicate", "Measurement")))
+  expect_equal(nrow(result), 4)
+  expect_true(any(is.na(result$Measurement)))
+  expect_equal(result$Measurement[result$Sample == "1" & result$Replicate == "R1"], 1.5)
+})
+
+test_that("convert_wide_to_long detects duplicate measurements per replicate", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R2"),
+    c("1", "A", "3", "4"),
+    c("1", "A", "5", "6")
+  ))
+
+  expect_error(convert_wide_to_long(path), "Duplicate measurements detected")
+})
+
+test_that("convert_wide_to_long tolerates extra header rows and empty cells", {
+  path <- make_workbook(rbind(
+    c("Sample", "Group", "Measurement", ""),
+    c("", "", "R1", "R2"),
+    c("Notes", "Ignore", "", ""),
+    c("3", "C", "7.5", "8.5")
+  ))
+
+  result <- convert_wide_to_long(path)
+
+  expect_equal(nrow(result), 4)
+  expect_true(any(is.na(result$Measurement)))
+  expect_true(all(result$Replicate %in% c("R1", "R2")))
+})
+
+
+test_that("preprocess_uploaded_table orders factors numerically and keeps NAs", {
+  df <- data.frame(
+    sample_id = 1:4,
+    treatment = c("T2", "T10", "T1", NA),
+    batch = rep("Only", 4),
+    stringsAsFactors = FALSE
+  )
+
+  processed <- preprocess_uploaded_table(df)
+
+  expect_s3_class(processed$treatment, "factor")
+  expect_equal(levels(processed$treatment), c("T1", "T2", "T10"))
+  expect_true(any(is.na(processed$treatment)))
+  expect_equal(levels(processed$batch), "Only")
+})


### PR DESCRIPTION
## Summary
- rewrite wide-to-long upload tests into testthat cases and cover duplicate/empty header scenarios
- add validation tests for upload preprocessing, error formatting, and ANOVA helpers with stratification edge cases
- retain regression helper checks for numeric/factor detection across extreme values

## Testing
- `Rscript -e "testthat::test_dir('tests')"` *(not run: Rscript not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b24565084832b9fba1fc504d8cd0d)