### PR TITLE
Update README transparency to reference R functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,22 +99,21 @@ MIT (or update with your project’s chosen license).
 Built by the Table Analyzer team. Inspired by best practices for transparent statistical reporting and reproducible research.
 
 ---
-
 ## 🔍 Transparency for users and reviewers
 
-Every analysis tab in Table Analyzer maps directly to a small set of R functions. The table below lists the key routines, the underlying packages, and the core arguments populated by the UI for each analysis.
+Every analysis tab in Table Analyzer maps directly to familiar R functions. The table below summarizes what is executed and which options the UI fills in on your behalf.
 
-| Module | Core functions | Key arguments populated by the app |
+| Module | Core R routines | Key options populated by the app |
 | --- | --- | --- |
-| Descriptive statistics | `compute_descriptive_summary()` → `skimr::skim()`; `dplyr::summarise()` for coefficient of variation, outliers, and five-number summaries. | Selected categorical variables (`cat_vars`), numeric variables (`num_vars`), optional stratification factor (`group_var`). Missing values are excluded column-wise for each summary statistic. |
-| One-way ANOVA | `prepare_stratified_anova()` builds `stats::aov(response ~ factor)` models; `car::Anova(model, type = 3)` for Type-III tables; `emmeans::emmeans()` with `contrast(..., method = "pairwise", adjust = "tukey")` for post-hoc tests. | Responses chosen in the UI (`responses`), single categorical predictor (`factor1_var`) with reordered levels (`factor1_order`), optional stratification factor. |
-| Two-way ANOVA | Same pipeline as one-way, but formulas expand to `stats::aov(response ~ factor1 * factor2)` and Tukey-adjusted post-hoc contrasts are produced for each main effect. | Responses plus two categorical predictors (`factor1_var`, `factor2_var`) and their level orders; optional stratification variable controlling per-stratum models. |
-| Linear model (LM) | `reg_fit_model()` wraps `stats::lm(response ~ predictors)`; summaries combine `car::Anova(model, type = 3)` and `summary.lm()`. Residual diagnostics are produced with `stats::fitted()`/`stats::residuals()` and `stats::qqnorm()`. | Numeric response (`dep`), categorical predictors (`fixed`), numeric covariates (`covar`), optional two-way interactions (`interactions`). Stratification fits one model per stratum. |
-| Linear mixed model (LMM) | `reg_fit_model()` dispatches to `lmerTest::lmer(response ~ fixed + covar + interactions + (1\|random))`; inference uses `anova(model, type = 3)` from **lmerTest** and `summary()` with intraclass correlation from `compute_icc()` (based on `lme4::VarCorr()`). | Same arguments as LM plus a random intercept factor (`random`). |
-| Pairwise correlations | `cor()` with `use = "pairwise.complete.obs"` for numeric matrices; optional stratified splits. Visual diagnostics use `GGally::ggpairs()` with point, density, and correlation panels. | Numeric variables selected in the UI (`vars`) and optional stratification factor; each stratum is analyzed independently when supplied. |
-| Principal component analysis | `stats::prcomp(data, center = TRUE, scale. = TRUE)` on complete cases for the selected columns. Outputs include `summary(prcomp)` and the loadings matrix. | Numeric variables (`vars`). Rows with missing values in any selected variable are excluded prior to fitting, and the count of excluded rows is reported. |
+| Descriptive statistics | `skimr::skim()` for overall and stratified summaries; `dplyr::summarise()` to add coefficients of variation, outlier counts, and five-number summaries. | Selected categorical variables, numeric variables, optional stratification factor. Missing values are dropped column-wise for each summary. |
+| One-way ANOVA | `stats::aov(response ~ factor)` with Type-III tests from `car::Anova(type = 3)`; pairwise group comparisons via `emmeans::emmeans()` + `contrast(..., method = "pairwise", adjust = "tukey")`. | Responses chosen in the UI, single categorical predictor with user-defined level order, optional stratification factor. |
+| Two-way ANOVA | `stats::aov(response ~ factor1 * factor2)` with Type-III tables from `car::Anova()` and Tukey-adjusted marginal means for each main effect through `emmeans`. | Responses plus two categorical predictors and their level orders; optional stratification variable drives per-stratum models. |
+| Linear model (LM) | `stats::lm(response ~ predictors)`; inference combines `car::Anova(type = 3)` and `summary.lm()`, with residual plots based on fitted values, residuals, and Q-Q diagnostics from `stats`. | Numeric response, categorical predictors, numeric covariates, optional two-way interactions. Stratification fits one model per subgroup. |
+| Linear mixed model (LMM) | `lmerTest::lmer(response ~ fixed + covariates + interactions + (1|random))`; fixed-effect tests via `anova(type = 3)` from **lmerTest**, ICC derived from `lme4::VarCorr()`; residual checks mirror the LM module. | Same inputs as LM plus a random-intercept factor. Stratification runs a separate mixed model for each level. |
+| Pairwise correlations | `stats::cor(..., use = "pairwise.complete.obs")` for coefficients; visual diagnostics via `GGally::ggpairs()` with correlation, scatter, and density panels. | Numeric variables selected in the UI and optional stratification factor; each stratum is analyzed independently. |
+| Principal component analysis | `stats::prcomp(center = TRUE, scale. = TRUE)` applied to complete cases for the selected columns, with variance summaries from `summary(prcomp)` and loadings displayed. | Numeric variables selected for PCA. Rows missing any selected variable are removed before fitting, and the excluded count is reported. |
 
-When exporting results, each module bundles the rendered tables, model summaries, and diagnostic plots for the exact function calls above. This makes it straightforward for reviewers to reproduce the analyses or to cite the software in a methods section.
+When exporting results, each module bundles the rendered tables, model summaries, and diagnostic plots based on these function calls, enabling straightforward reproduction and review.
 
 ---
 


### PR DESCRIPTION
## Summary
- rewrite the transparency section to describe each module in terms of well-known R functions and packages
- remove internal helper names from the README so the documentation matches the user-facing code paths
- emphasize how stratification and exports relate to the underlying R calls for reproducibility

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b486026b8832b881900f46bd0fbc0)