### PR TITLE
Allow configuring replicate column name for wide uploads

### DIFF
--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -26,6 +26,7 @@ upload_ui <- function(id) {
       uiOutput(ns("layout_example")),
       uiOutput(ns("file_input")),
       uiOutput(ns("sheet_selector")),
+      uiOutput(ns("replicate_col_input")),
       uiOutput(ns("type_selectors"))
     ),
     mainPanel(
@@ -122,6 +123,23 @@ upload_server <- function(id) {
         "Provide the Excel workbook that stores your study measurements."
       )
     })
+
+    output$replicate_col_input <- renderUI({
+      req(input$data_source)
+      if (input$data_source != "wide") {
+        return(NULL)
+      }
+
+      with_help_tooltip(
+        textInput(
+          ns("replicate_col"),
+          label = "Replicate column name",
+          value = "Replicate",
+          placeholder = "Replicate"
+        ),
+        "Choose the column name that will store the second header row when wide data is reshaped."
+      )
+    })
     
     # -----------------------------------------------------------
     # 2️⃣ Example layout preview
@@ -196,10 +214,17 @@ upload_server <- function(id) {
       path <- input$file$datapath
 
       if (input$data_source == "wide") {
+        replicate_col <- input$replicate_col
+        if (is.null(replicate_col) || !nzchar(trimws(replicate_col))) {
+          replicate_col <- "Replicate"
+        } else {
+          replicate_col <- trimws(replicate_col)
+        }
+
         safe_result <- safe_convert_wide_to_long(
           path,
           sheet = input$sheet,
-          replicate_col = "Replicate"
+          replicate_col = replicate_col
         )
 
         if (!handle_safe_result(

--- a/tests/test_convert_wide_to_long.R
+++ b/tests/test_convert_wide_to_long.R
@@ -150,6 +150,10 @@ test_that("convert_wide_to_long behaves correctly across 20 Excel scenarios", {
   # Replicate column must contain Rep1 and Rep2
   rep_vals <- as.character(out1$result$Replicate)
   expect_true(all(rep_vals %in% c("Rep1", "Rep2")))
+
+  custom_rep_result <- convert_wide_to_long(paths[[1]], replicate_col = "Run")
+  expect_true(all(c("Run", "A", "B") %in% names(custom_rep_result)))
+  expect_true(all(as.character(custom_rep_result$Run) %in% c("Rep1", "Rep2")))
   
   
   # ---- Test 2 ----


### PR DESCRIPTION
## Summary
- add a configurable text input so users can set the replicate column name when uploading wide-format data
- pass the chosen replicate column name through the wide-to-long conversion with a sensible default
- extend the wide-format conversion tests to cover custom replicate column naming

## Testing
- Not run (Rscript unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4a08c744832b8ff9088be3cef001)