### PR TITLE
Prevent showing plots with invalid grid layouts

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -262,6 +262,12 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
 
       if (!identical(key, cached_key())) {
         info <- plot_info()
+        if (!is.null(info$warning)) {
+          cached_plot(NULL)
+          cached_key(key)
+          return()
+        }
+
         if (!is.null(info$plot)) {
           cached_plot(info$plot)
           cached_key(key)

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -438,6 +438,12 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       )
       if (!identical(key, cached_key())) {
         info <- plot_info()
+        if (!is.null(info$warning)) {
+          cached_plot(NULL)
+          cached_key(key)
+          return()
+        }
+
         if (!is.null(info$plot)) {
           cached_plot(info$plot)
           cached_key(key)

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -263,6 +263,13 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       )
       if (!identical(key, cached_key())) {
         info <- isolate(plot_info())
+
+        if (!is.null(info$warning)) {
+          cached_plot(NULL)
+          cached_key(key)
+          return()
+        }
+
         if (!is.null(info$plot)) {
           cached_plot(info$plot)
           cached_key(key)

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -290,6 +290,13 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       
       if (!identical(key, cached_key())) {
         info <- isolate(plot_info())
+
+        if (!is.null(info$warning)) {
+          cached_plot(NULL)
+          cached_key(key)
+          return()
+        }
+
         if (!is.null(info$plot)) {
           cached_plot(info$plot)
           cached_key(key)

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -259,6 +259,13 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       
       if (!identical(key, cached_key())) {
         info <- isolate(plot_info())
+
+        if (!is.null(info$warning)) {
+          cached_plot(NULL)
+          cached_key(key)
+          return()
+        }
+
         if (!is.null(info$plot)) {
           cached_plot(info$plot)
           cached_key(key)

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -226,9 +226,16 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         s$plot_w, s$plot_h,
         sep = "_"
       )
-      
+
       if (!identical(key, cached_key())) {
         info <- plot_info()
+        if (!is.null(info$warning)) {
+          cached_plot(NULL)
+          cached_layout(NULL)
+          cached_key(key)
+          return()
+        }
+
         if (!is.null(info$plot)) {
           cached_plot(info$plot)
           cached_layout(info$layout)


### PR DESCRIPTION
## Summary
- clear cached plots when grid validation fails across visualization modules
- avoid rendering stale multi-grid plots when layout is too small or too large

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c5010e5c0832bb9c280ca0ed4d3dd)