### PR TITLE
Populate grid inputs with computed defaults

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -231,7 +231,13 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       )
       res[[if (!is.null(s$plot_type) && s$plot_type %in% names(res)) s$plot_type else "lineplot_mean_se"]]
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "strata_grid", info$defaults$strata)
+      apply_grid_defaults_if_empty(input, session, "response_grid", info$defaults$responses)
+    }, ignoreNULL = TRUE)
+
     # ---- Cached ggplot to prevent flicker ----
     hash_key <- function(data) {
       if (is.null(data) || !is.data.frame(data)) return("no-data")

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -405,7 +405,13 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       )
       res[[if (!is.null(s$plot_type) && s$plot_type %in% names(res)) s$plot_type else "lineplot_mean_se"]]
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "strata_grid", info$defaults$strata)
+      apply_grid_defaults_if_empty(input, session, "response_grid", info$defaults$responses)
+    }, ignoreNULL = TRUE)
+
     # ---- Cached ggplot object to avoid flicker ----
     hash_key <- function(data) {
       if (is.null(data) || !is.data.frame(data)) return("no-data")

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -150,6 +150,12 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
       )
     })
 
+    observeEvent(plot_info(), {
+      req(active())
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+    }, ignoreNULL = TRUE)
+
     common_legend_available <- reactive({
       req(active())
       info <- plot_info()

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -176,6 +176,12 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
       )
     })
 
+    observeEvent(plot_info(), {
+      req(active())
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+    }, ignoreNULL = TRUE)
+
     common_legend_available <- reactive({
       req(active())
       info <- plot_info()

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -146,6 +146,12 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       )
     })
 
+    observeEvent(plot_info(), {
+      req(active())
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+    }, ignoreNULL = TRUE)
+
     common_legend_available <- reactive({
       req(active())
       info <- plot_info()

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -159,7 +159,8 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         return(list(
           plot = plot,
           layout = list(rows = defaults$rows, cols = defaults$cols),
-          warning = NULL
+          warning = NULL,
+          defaults = defaults
         ))
       }
       
@@ -201,11 +202,12 @@ pairwise_correlation_visualize_ggpairs_server <- function(
                                           ncol = layout$ncol
         )
       }
-      
+
       list(
         plot = combined,
         layout = list(rows = layout$nrow, cols = layout$ncol),
-        warning = val$message
+        warning = val$message,
+        defaults = defaults
       )
     })
     
@@ -243,7 +245,12 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         }
       }
     })
-    
+
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+    }, ignoreNULL = TRUE)
+
     # ---- Unified sizing -------------------------------------------------------
     plot_dimensions <- reactive({
       lay <- cached_layout()

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -519,6 +519,11 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
       )
     })
 
+    observeEvent(plot_info(), {
+      info <- plot_info()
+      apply_grid_defaults_if_empty(input, session, "facet_grid", info$defaults)
+    }, ignoreNULL = TRUE)
+
     # ---- Unified sizing logic ----
     size_val <- reactiveVal(list(w = 800, h = 600))
     

--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -59,6 +59,29 @@ basic_grid_layout <- function(rows = NULL,
   )
 }
 
+apply_grid_defaults_if_empty <- function(input, session, grid_id, defaults) {
+  if (is.null(defaults) || !is.list(defaults)) return()
+
+  rows_default <- suppressWarnings(as.integer(defaults$rows[1]))
+  cols_default <- suppressWarnings(as.integer(defaults$cols[1]))
+
+  if (any(!is.finite(c(rows_default, cols_default)))) return()
+
+  rows_id <- paste0(grid_id, "-rows")
+  cols_id <- paste0(grid_id, "-cols")
+
+  current_rows <- isolate(input[[rows_id]])
+  current_cols <- isolate(input[[cols_id]])
+
+  if (is.null(current_rows) || is.na(current_rows)) {
+    updateNumericInput(session, rows_id, value = rows_default)
+  }
+
+  if (is.null(current_cols) || is.na(current_cols)) {
+    updateNumericInput(session, cols_id, value = cols_default)
+  }
+}
+
 adjust_grid_layout <- function(n_items, layout) {
   if (is.null(layout) || length(layout) == 0) {
     return(list(nrow = 1L, ncol = 1L))


### PR DESCRIPTION
## Summary
- add a helper to populate grid controls with computed defaults when values are missing
- auto-fill grid row and column inputs across multi-grid visualizations after layouts are calculated to avoid empty widgets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c522b1b84832b9e0bdc6c2b4e1992)