### PR TITLE
Reset plot grids when visualization panel counts change

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -234,8 +234,8 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
 
     observeEvent(plot_info(), {
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "strata_grid", info$defaults$strata)
-      apply_grid_defaults_if_empty(input, session, "response_grid", info$defaults$responses)
+      apply_grid_defaults_if_empty(input, session, "strata_grid", info$defaults$strata, n_items = info$panel_counts$strata)
+      apply_grid_defaults_if_empty(input, session, "response_grid", info$defaults$responses, n_items = info$panel_counts$responses)
     }, ignoreNULL = TRUE)
 
     # ---- Cached ggplot to prevent flicker ----

--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -967,6 +967,11 @@ finalize_anova_plot_result <- function(response_plots,
   }
   warning_text <- if (length(warnings) > 0) paste(warnings, collapse = "<br/>") else NULL
 
+  panel_counts <- list(
+    strata = if (has_strata) max(1L, strata_panel_count) else 1L,
+    responses = length(response_plots)
+  )
+
   final_plot <- NULL
   if (is.null(warning_text)) {
     if (length(response_plots) == 1) {
@@ -1003,6 +1008,7 @@ finalize_anova_plot_result <- function(response_plots,
       )
     ),
     warning = warning_text,
+    panel_counts = panel_counts,
     defaults = list(
       strata = context$strata_defaults,
       responses = response_defaults

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -408,8 +408,8 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
 
     observeEvent(plot_info(), {
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "strata_grid", info$defaults$strata)
-      apply_grid_defaults_if_empty(input, session, "response_grid", info$defaults$responses)
+      apply_grid_defaults_if_empty(input, session, "strata_grid", info$defaults$strata, n_items = info$panel_counts$strata)
+      apply_grid_defaults_if_empty(input, session, "response_grid", info$defaults$responses, n_items = info$panel_counts$responses)
     }, ignoreNULL = TRUE)
 
     # ---- Cached ggplot object to avoid flicker ----

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -153,7 +153,7 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
     observeEvent(plot_info(), {
       req(active())
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults, n_items = info$panels)
     }, ignoreNULL = TRUE)
 
     common_legend_available <- reactive({

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -179,7 +179,7 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
     observeEvent(plot_info(), {
       req(active())
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults, n_items = info$panels)
     }, ignoreNULL = TRUE)
 
     common_legend_available <- reactive({

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -149,7 +149,7 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
     observeEvent(plot_info(), {
       req(active())
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults, n_items = info$panels)
     }, ignoreNULL = TRUE)
 
     common_legend_available <- reactive({

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -159,6 +159,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         return(list(
           plot = plot,
           layout = list(rows = defaults$rows, cols = defaults$cols),
+          panels = 1L,
           warning = NULL,
           defaults = defaults
         ))
@@ -206,6 +207,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(
       list(
         plot = combined,
         layout = list(rows = layout$nrow, cols = layout$ncol),
+        panels = n_panels,
         warning = val$message,
         defaults = defaults
       )
@@ -248,7 +250,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(
 
     observeEvent(plot_info(), {
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults)
+      apply_grid_defaults_if_empty(input, session, "plot_grid", info$defaults, n_items = info$panels)
     }, ignoreNULL = TRUE)
 
     # ---- Unified sizing -------------------------------------------------------

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -521,7 +521,7 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
 
     observeEvent(plot_info(), {
       info <- plot_info()
-      apply_grid_defaults_if_empty(input, session, "facet_grid", info$defaults)
+      apply_grid_defaults_if_empty(input, session, "facet_grid", info$defaults, n_items = info$panels)
     }, ignoreNULL = TRUE)
 
     # ---- Unified sizing logic ----

--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -59,7 +59,7 @@ basic_grid_layout <- function(rows = NULL,
   )
 }
 
-apply_grid_defaults_if_empty <- function(input, session, grid_id, defaults) {
+apply_grid_defaults_if_empty <- function(input, session, grid_id, defaults, n_items = NULL) {
   if (is.null(defaults) || !is.list(defaults)) return()
 
   rows_default <- suppressWarnings(as.integer(defaults$rows[1]))
@@ -73,11 +73,26 @@ apply_grid_defaults_if_empty <- function(input, session, grid_id, defaults) {
   current_rows <- isolate(input[[rows_id]])
   current_cols <- isolate(input[[cols_id]])
 
-  if (is.null(current_rows) || is.na(current_rows)) {
+  needs_reset <- function(value) {
+    if (length(value) == 0) return(TRUE)
+    v <- suppressWarnings(as.integer(value[1]))
+    is.na(v)
+  }
+
+  is_invalid_for_grid <- function(rows, cols) {
+    if (is.null(n_items)) return(FALSE)
+    validation <- validate_grid(n_items, rows, cols)
+    isFALSE(validation$valid)
+  }
+
+  reset_rows <- needs_reset(current_rows) || is_invalid_for_grid(current_rows, current_cols)
+  reset_cols <- needs_reset(current_cols) || is_invalid_for_grid(current_rows, current_cols)
+
+  if (reset_rows) {
     updateNumericInput(session, rows_id, value = rows_default)
   }
 
-  if (is.null(current_cols) || is.na(current_cols)) {
+  if (reset_cols) {
     updateNumericInput(session, cols_id, value = cols_default)
   }
 }


### PR DESCRIPTION
## Summary
- Reset grid inputs to default values when existing settings are missing or invalid for the current number of panels
- Supply panel counts to grid layout helpers across ANOVA, descriptive, PCA, and correlation visualizations
- Include panel count metadata in correlation plot results to support grid resets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c59cd1ec0832ba8e96831866babe6)