### PR TITLE
Refactor subplot size inputs into reusable submodule

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -62,16 +62,7 @@ visualize_oneway_ui <- function(id) {
         ),
         "Lock the y-axis range so all subplots share the same scale."
       ),
-      fluidRow(
-        column(6, with_help_tooltip(
-          numericInput(ns("plot_width"), "Subplot width (px)", value = 400, min = 200, max = 2000, step = 50),
-          "Adjust how wide each subplot should be in pixels."
-        )),
-        column(6, with_help_tooltip(
-          numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 2000, step = 50),
-          "Adjust how tall each subplot should be in pixels."
-        ))
-      ),
+      subplot_size_ui(ns),
       uiOutput(ns("layout_controls")),
       fluidRow(
         column(6, add_color_customization_ui(ns, multi_group = FALSE)),

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -55,16 +55,7 @@ visualize_twoway_ui <- function(id) {
         )
       ),
       uiOutput(ns("axis_and_jitter")),
-      fluidRow(
-        column(6, with_help_tooltip(
-          numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 2000, step = 50),
-          "Set how wide each subplot should be in pixels."
-        )),
-        column(6, with_help_tooltip(
-          numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 2000, step = 50),
-          "Set how tall each subplot should be in pixels."
-        ))
-      ),
+      subplot_size_ui(ns),
       uiOutput(ns("layout_controls")),
       fluidRow(
         column(6, add_color_customization_ui(ns, multi_group = TRUE)),

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -13,15 +13,10 @@ visualize_categorical_barplots_ui <- function(id) {
       checkboxInput(ns("show_value_labels"), "Show value labels on bars", FALSE),
       "Display the numeric value on top of each bar."
     ),
-    fluidRow(
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 2000, step = 50),
-        "Set the width of each categorical plot in pixels."
-      )),
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 2000, step = 50),
-        "Set the height of each categorical plot in pixels."
-      ))
+    subplot_size_ui(
+      ns,
+      width_help = "Set the width of each categorical plot in pixels.",
+      height_help = "Set the height of each categorical plot in pixels."
     ),
     plot_grid_ui(
       id = ns("plot_grid"),

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -7,15 +7,12 @@ metric_panel_ui <- function(id, default_width = 400, default_height = 300,
                             default_rows = 1, default_cols = 1) {
   ns <- NS(id)
   tagList(
-    fluidRow(
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_width"),  "Subplot width (px)",  default_width, min = 200, max = 2000, step = 50),
-        "Set the width of each metric panel in pixels."
-      )),
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_height"), "Subplot height (px)", default_height, min = 200, max = 2000, step = 50),
-        "Set the height of each metric panel in pixels."
-      ))
+    subplot_size_ui(
+      ns,
+      width_value = default_width,
+      height_value = default_height,
+      width_help = "Set the width of each metric panel in pixels.",
+      height_help = "Set the height of each metric panel in pixels."
     ),
     fluidRow(
       column(6, add_color_customization_ui(ns, multi_group = TRUE)),

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -17,15 +17,12 @@ visualize_numeric_boxplots_ui <- function(id) {
       condition = sprintf("input['%s']", ns("show_outliers")),
       uiOutput(ns("outlier_label_ui"))
     ),
-    fluidRow(
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_width"),  "Subplot width (px)",  value = 200, min = 200, max = 2000, step = 50),
-        "Control how wide each boxplot panel should be."
-      )),
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_height"), "Subplot height (px)", value = 800, min = 200, max = 2000, step = 50),
-        "Control how tall each boxplot panel should be."
-      ))
+    subplot_size_ui(
+      ns,
+      width_value = 200,
+      height_value = 800,
+      width_help = "Control how wide each boxplot panel should be.",
+      height_help = "Control how tall each boxplot panel should be."
     ),
     plot_grid_ui(
       id = ns("plot_grid"),

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -9,15 +9,10 @@ visualize_numeric_histograms_ui <- function(id) {
       checkboxInput(ns("use_density"), "Show density instead of count", FALSE),
       "Switch between showing counts or densities for each histogram."
     ),
-    fluidRow(
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_width"),  "Subplot width (px)",  value = 400, min = 200, max = 2000, step = 50),
-        "Set the width of each histogram panel in pixels."
-      )),
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_height"), "Subplot height (px)", value = 300, min = 200, max = 2000, step = 50),
-        "Set the height of each histogram panel in pixels."
-      ))
+    subplot_size_ui(
+      ns,
+      width_help = "Set the width of each histogram panel in pixels.",
+      height_help = "Set the height of each histogram panel in pixels."
     ),
     plot_grid_ui(
       id = ns("plot_grid"),

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -5,15 +5,12 @@
 pairwise_correlation_visualize_ggpairs_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    fluidRow(
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_width"),  "Subplot width (px)",  value = 800, min = 200, max = 2000, step = 50),
-        "Set the width in pixels for each panel of the correlation matrix."
-      )),
-      column(6, with_help_tooltip(
-        numericInput(ns("plot_height"), "Subplot height (px)", value = 600, min = 200, max = 2000, step = 50),
-        "Set the height in pixels for each panel of the correlation matrix."
-      ))
+    subplot_size_ui(
+      ns,
+      width_value = 800,
+      height_value = 600,
+      width_help = "Set the width in pixels for each panel of the correlation matrix.",
+      height_help = "Set the height in pixels for each panel of the correlation matrix."
     ),
     plot_grid_ui(
       id = ns("plot_grid"),

--- a/R/submodule_subplot_size.R
+++ b/R/submodule_subplot_size.R
@@ -1,0 +1,69 @@
+# ===============================================================
+# 📏 Submodule — Subplot Size Controls
+# ===============================================================
+
+subplot_size_defaults <- function() {
+  list(
+    width = list(
+      label = "Subplot width (px)",
+      value = 400,
+      min = 200,
+      max = 2000,
+      step = 50,
+      help = "Adjust how wide each subplot should be in pixels."
+    ),
+    height = list(
+      label = "Subplot height (px)",
+      value = 300,
+      min = 200,
+      max = 2000,
+      step = 50,
+      help = "Adjust how tall each subplot should be in pixels."
+    )
+  )
+}
+
+subplot_size_ui <- function(
+    ns,
+    width_value = NULL,
+    height_value = NULL,
+    width_help = NULL,
+    height_help = NULL,
+    width_label = NULL,
+    height_label = NULL,
+    width_id = "plot_width",
+    height_id = "plot_height") {
+  defaults <- subplot_size_defaults()
+
+  width_value  <- if (is.null(width_value)) defaults$width$value else width_value
+  height_value <- if (is.null(height_value)) defaults$height$value else height_value
+  width_help   <- if (is.null(width_help)) defaults$width$help else width_help
+  height_help  <- if (is.null(height_help)) defaults$height$help else height_help
+  width_label  <- if (is.null(width_label)) defaults$width$label else width_label
+  height_label <- if (is.null(height_label)) defaults$height$label else height_label
+
+  fluidRow(
+    column(6, with_help_tooltip(
+      numericInput(
+        ns(width_id),
+        width_label,
+        value = width_value,
+        min = defaults$width$min,
+        max = defaults$width$max,
+        step = defaults$width$step
+      ),
+      width_help
+    )),
+    column(6, with_help_tooltip(
+      numericInput(
+        ns(height_id),
+        height_label,
+        value = height_value,
+        min = defaults$height$min,
+        max = defaults$height$max,
+        step = defaults$height$step
+      ),
+      height_help
+    ))
+  )
+}


### PR DESCRIPTION
## Summary
- add a shared subplot size submodule with centralized defaults
- replace repeated width/height inputs across visualization modules with the shared helper while preserving module-specific defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c695636b8832bb63e16f27152f182)