### PR TITLE
Stop resetting grid inputs when validation fails

### DIFF
--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -79,14 +79,8 @@ apply_grid_defaults_if_empty <- function(input, session, grid_id, defaults, n_it
     is.na(v)
   }
 
-  is_invalid_for_grid <- function(rows, cols) {
-    if (is.null(n_items)) return(FALSE)
-    validation <- validate_grid(n_items, rows, cols)
-    isFALSE(validation$valid)
-  }
-
-  reset_rows <- needs_reset(current_rows) || is_invalid_for_grid(current_rows, current_cols)
-  reset_cols <- needs_reset(current_cols) || is_invalid_for_grid(current_rows, current_cols)
+  reset_rows <- needs_reset(current_rows)
+  reset_cols <- needs_reset(current_cols)
 
   if (reset_rows) {
     updateNumericInput(session, rows_id, value = rows_default)


### PR DESCRIPTION
## Summary
- prevent grid inputs from being reset to defaults when existing values are invalid for the current plot layout
- keep defaulting behavior only when grid inputs are empty or non-numeric

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6d281a6c832bb1aaae8e46f244b2)