### PR TITLE
Remove plot gridlines globally

### DIFF
--- a/app.R
+++ b/app.R
@@ -23,6 +23,8 @@ library(skimr)
 library(tidyr)
 library(zoo)
 
+theme_set(theme_get() + theme(panel.grid.major = element_blank(), panel.grid.minor = element_blank()))
+
 options(shiny.autoreload = TRUE)
 options(shiny.maxRequestSize = 200 * 1024^2)
 


### PR DESCRIPTION
## Summary
- apply a global ggplot theme that removes major and minor panel gridlines across the app

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6f2fb8d8832b91641bd46d7df4c3)