### PR TITLE
Remove plot grids within individual plots

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1068,8 +1068,8 @@ build_line_plot_panel <- function(stats_df,
       theme_minimal(base_size = base_size) +
       labs(x = factor1, y = "Mean ± SE") +
       theme(
-        panel.grid.minor = element_blank(),
-        panel.grid.major.x = element_blank()
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank()
       )
   } else {
     group_levels <- if (is.factor(stats_df[[factor2]])) {
@@ -1145,8 +1145,8 @@ build_line_plot_panel <- function(stats_df,
         color = factor2
       ) +
       theme(
-        panel.grid.minor = element_blank(),
-        panel.grid.major.x = element_blank()
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank()
       ) +
       scale_color_manual(values = palette)
   }
@@ -1465,9 +1465,8 @@ build_single_factor_barplot <- function(stats_df,
       plot.title = element_text(size = 14, face = "bold", hjust = 0.5),
       axis.title.x = element_text(margin = margin(t = 6)),
       axis.title.y = element_text(margin = margin(r = 6)),
+      panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      panel.grid.major.x = element_blank(),
-      panel.grid.major.y = element_line(color = "gray90"),
       axis.text.x = element_text(angle = 0, hjust = 0.5)
     )
 
@@ -1534,9 +1533,8 @@ build_two_factor_barplot <- function(stats_df,
       plot.title = element_text(size = 14, face = "bold", hjust = 0.5),
       axis.title.x = element_text(margin = margin(t = 6)),
       axis.title.y = element_text(margin = margin(r = 6)),
+      panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      panel.grid.major.x = element_blank(),
-      panel.grid.major.y = element_line(color = "gray90"),
       axis.text.x = element_text(angle = 0, hjust = 0.5)
     ) +
     scale_fill_manual(values = palette)

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -437,7 +437,11 @@ build_descriptive_categorical_plot <- function(df,
         scale_fill_manual(values = palette) +
         theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label, fill = group_col) +
-        theme(axis.text.x = element_text(angle = 45, hjust = 1))
+        theme(
+          axis.text.x = element_text(angle = 45, hjust = 1),
+          panel.grid.major = element_blank(),
+          panel.grid.minor = element_blank()
+        )
 
       p <- add_value_labels(p, count_df, show_value_labels, show_proportions, group_dodge, base_size)
       p <- apply_value_scale(p, show_proportions, show_value_labels)
@@ -465,7 +469,11 @@ build_descriptive_categorical_plot <- function(df,
         geom_col(fill = single_fill, width = 0.65) +
         theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label) +
-        theme(axis.text.x = element_text(angle = 45, hjust = 1))
+        theme(
+          axis.text.x = element_text(angle = 45, hjust = 1),
+          panel.grid.major = element_blank(),
+          panel.grid.minor = element_blank()
+        )
 
       p <- add_value_labels(p, count_df, show_value_labels, show_proportions, base_size = base_size)
       p <- apply_value_scale(p, show_proportions, show_value_labels)

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -190,6 +190,7 @@ build_metric_plot <- function(metric_info,
     labs(x = NULL, y = y_label, title = title) +
     theme(
       axis.text.x = element_text(angle = 45, hjust = 1),
+      panel.grid.major = element_blank(),
       panel.grid.minor = element_blank()
     )
 }

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -365,7 +365,11 @@ build_descriptive_numeric_boxplot <- function(df,
         scale_fill_manual(values = palette) +
         theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = var) +
-        theme(axis.text.x = element_text(angle = 45, hjust = 1))
+        theme(
+          axis.text.x = element_text(angle = 45, hjust = 1),
+          panel.grid.major = element_blank(),
+          panel.grid.minor = element_blank()
+        )
 
       needs_color_scale <- FALSE
       if (isTRUE(show_points)) {
@@ -421,7 +425,12 @@ build_descriptive_numeric_boxplot <- function(df,
         geom_boxplot(fill = single_color, width = 0.3) +
         theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = var) +
-        theme(axis.text.x = element_blank(), axis.ticks.x = element_blank())
+        theme(
+          axis.text.x = element_blank(),
+          axis.ticks.x = element_blank(),
+          panel.grid.major = element_blank(),
+          panel.grid.minor = element_blank()
+        )
 
       if (isTRUE(show_points)) {
         p <- p + geom_jitter(color = single_color, width = 0.05, alpha = 0.5, size = 1)

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -374,7 +374,11 @@ build_descriptive_numeric_histogram <- function(df,
 
     base +
       theme_minimal(base_size = base_size) +
-      labs(title = var, x = var, y = y_label)
+      labs(title = var, x = var, y = y_label) +
+      theme(
+        panel.grid.major = element_blank(),
+        panel.grid.minor = element_blank()
+      )
   })
 
   plots <- Filter(Negate(is.null), plots)

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -674,6 +674,8 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
     ) +
     theme(
       plot.title = element_text(size = 16, face = "bold"),
+      panel.grid.major = element_blank(),
+      panel.grid.minor = element_blank(),
       legend.position = "right"
     )
   

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -150,7 +150,11 @@ render_residual_plot <- function(model_obj) {
       x = "Fitted values",
       y = "Residuals"
     ) +
-    ggplot2::theme_minimal(base_size = 13)
+    ggplot2::theme_minimal(base_size = 13) +
+    ggplot2::theme(
+      panel.grid.major = ggplot2::element_blank(),
+      panel.grid.minor = ggplot2::element_blank()
+    )
 }
 
 render_qq_plot <- function(model_obj) {
@@ -169,7 +173,11 @@ render_qq_plot <- function(model_obj) {
       x = "Theoretical quantiles",
       y = "Sample quantiles"
     ) +
-    ggplot2::theme_minimal(base_size = 13)
+    ggplot2::theme_minimal(base_size = 13) +
+    ggplot2::theme(
+      panel.grid.major = ggplot2::element_blank(),
+      panel.grid.minor = ggplot2::element_blank()
+    )
 }
 
 assign_download_handler <- function(output, id, engine, response, stratum_display, model_obj) {


### PR DESCRIPTION
## Summary
- revert the global ggplot theme override
- explicitly remove panel gridlines within each plot creation routine across the app

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6f2fb8d8832b91641bd46d7df4c3)