### PR TITLE
Restore axes across plots

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1069,7 +1069,9 @@ build_line_plot_panel <- function(stats_df,
       labs(x = factor1, y = "Mean ± SE") +
       theme(
         panel.grid.major = element_blank(),
-        panel.grid.minor = element_blank()
+        panel.grid.minor = element_blank(),
+        axis.line = element_line(color = "gray30"),
+        axis.ticks = element_line(color = "gray30")
       )
   } else {
     group_levels <- if (is.factor(stats_df[[factor2]])) {
@@ -1146,7 +1148,9 @@ build_line_plot_panel <- function(stats_df,
       ) +
       theme(
         panel.grid.major = element_blank(),
-        panel.grid.minor = element_blank()
+        panel.grid.minor = element_blank(),
+        axis.line = element_line(color = "gray30"),
+        axis.ticks = element_line(color = "gray30")
       ) +
       scale_color_manual(values = palette)
   }
@@ -1467,7 +1471,9 @@ build_single_factor_barplot <- function(stats_df,
       axis.title.y = element_text(margin = margin(r = 6)),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      axis.text.x = element_text(angle = 0, hjust = 0.5)
+      axis.text.x = element_text(angle = 0, hjust = 0.5),
+      axis.line = element_line(color = "gray30"),
+      axis.ticks = element_line(color = "gray30")
     )
 
   expand_scale <- is.null(y_limits)
@@ -1535,7 +1541,9 @@ build_two_factor_barplot <- function(stats_df,
       axis.title.y = element_text(margin = margin(r = 6)),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      axis.text.x = element_text(angle = 0, hjust = 0.5)
+      axis.text.x = element_text(angle = 0, hjust = 0.5),
+      axis.line = element_line(color = "gray30"),
+      axis.ticks = element_line(color = "gray30")
     ) +
     scale_fill_manual(values = palette)
 

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -440,7 +440,9 @@ build_descriptive_categorical_plot <- function(df,
         theme(
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
-          panel.grid.minor = element_blank()
+          panel.grid.minor = element_blank(),
+          axis.line = element_line(color = "gray30"),
+          axis.ticks = element_line(color = "gray30")
         )
 
       p <- add_value_labels(p, count_df, show_value_labels, show_proportions, group_dodge, base_size)
@@ -472,7 +474,9 @@ build_descriptive_categorical_plot <- function(df,
         theme(
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
-          panel.grid.minor = element_blank()
+          panel.grid.minor = element_blank(),
+          axis.line = element_line(color = "gray30"),
+          axis.ticks = element_line(color = "gray30")
         )
 
       p <- add_value_labels(p, count_df, show_value_labels, show_proportions, base_size = base_size)

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -191,7 +191,9 @@ build_metric_plot <- function(metric_info,
     theme(
       axis.text.x = element_text(angle = 45, hjust = 1),
       panel.grid.major = element_blank(),
-      panel.grid.minor = element_blank()
+      panel.grid.minor = element_blank(),
+      axis.line = element_line(color = "gray30"),
+      axis.ticks = element_line(color = "gray30")
     )
 }
 

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -368,7 +368,9 @@ build_descriptive_numeric_boxplot <- function(df,
         theme(
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
-          panel.grid.minor = element_blank()
+          panel.grid.minor = element_blank(),
+          axis.line = element_line(color = "gray30"),
+          axis.ticks = element_line(color = "gray30")
         )
 
       needs_color_scale <- FALSE
@@ -429,7 +431,9 @@ build_descriptive_numeric_boxplot <- function(df,
           axis.text.x = element_blank(),
           axis.ticks.x = element_blank(),
           panel.grid.major = element_blank(),
-          panel.grid.minor = element_blank()
+          panel.grid.minor = element_blank(),
+          axis.line = element_line(color = "gray30"),
+          axis.ticks = element_line(color = "gray30")
         )
 
       if (isTRUE(show_points)) {

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -377,7 +377,9 @@ build_descriptive_numeric_histogram <- function(df,
       labs(title = var, x = var, y = y_label) +
       theme(
         panel.grid.major = element_blank(),
-        panel.grid.minor = element_blank()
+        panel.grid.minor = element_blank(),
+        axis.line = element_line(color = "gray30"),
+        axis.ticks = element_line(color = "gray30")
       )
   })
 

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -68,7 +68,9 @@ ggpairs_server <- function(id, data_reactive) {
           panel.grid.minor = ggplot2::element_blank(),
           panel.grid.major.x = ggplot2::element_blank(),
           panel.grid.major.y = ggplot2::element_blank(),
-          plot.title = ggplot2::element_text(size = 12, face = "bold")
+          plot.title = ggplot2::element_text(size = 12, face = "bold"),
+          axis.line = ggplot2::element_line(color = "gray30"),
+          axis.ticks = ggplot2::element_line(color = "gray30")
         )
     }
 

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -111,7 +111,9 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         ggplot2::theme(
           strip.text = ggplot2::element_text(face = "bold", size = 9),
           panel.grid.major = ggplot2::element_blank(),
-          panel.grid.minor = ggplot2::element_blank()
+          panel.grid.minor = ggplot2::element_blank(),
+          axis.line = ggplot2::element_line(color = "gray30"),
+          axis.ticks = ggplot2::element_line(color = "gray30")
         )
       
       if (!is.null(title)) p <- p + ggplot2::labs(title = title)

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -676,6 +676,8 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
       plot.title = element_text(size = 16, face = "bold"),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
+      axis.line = element_line(color = "gray30"),
+      axis.ticks = element_line(color = "gray30"),
       legend.position = "right"
     )
   

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -153,7 +153,9 @@ render_residual_plot <- function(model_obj) {
     ggplot2::theme_minimal(base_size = 13) +
     ggplot2::theme(
       panel.grid.major = ggplot2::element_blank(),
-      panel.grid.minor = ggplot2::element_blank()
+      panel.grid.minor = ggplot2::element_blank(),
+      axis.line = ggplot2::element_line(color = "gray30"),
+      axis.ticks = ggplot2::element_line(color = "gray30")
     )
 }
 
@@ -176,7 +178,9 @@ render_qq_plot <- function(model_obj) {
     ggplot2::theme_minimal(base_size = 13) +
     ggplot2::theme(
       panel.grid.major = ggplot2::element_blank(),
-      panel.grid.minor = ggplot2::element_blank()
+      panel.grid.minor = ggplot2::element_blank(),
+      axis.line = ggplot2::element_line(color = "gray30"),
+      axis.ticks = ggplot2::element_line(color = "gray30")
     )
 }
 


### PR DESCRIPTION
## Summary
- add consistent axis lines and ticks across visualizations to restore original axes
- ensure ANOVA barplots keep aligned axes even when significance annotations are present or absent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c751a35ac832bb35ffba7078db8e7)