### PR TITLE
Ensure ANOVA barplots start at zero

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1214,7 +1214,8 @@ ensure_barplot_zero_baseline <- function(range_vals) {
   lower <- range_vals[1]
   if (is.na(lower)) return(range_vals)
 
-  range_vals[1] <- min(0, lower)
+  # Keep barplots anchored at zero to avoid negative baselines when no annotations
+  range_vals[1] <- 0
   range_vals
 }
 


### PR DESCRIPTION
## Summary
- anchor ANOVA barplot y-axis limits at zero to avoid negative baselines when annotations are absent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c777cc81c832bb5b84f71ec52491a)