### PR TITLE
Anchor ANOVA barplot axes at zero with annotations

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1214,7 +1214,8 @@ ensure_barplot_zero_baseline <- function(range_vals) {
   lower <- range_vals[1]
   if (is.na(lower)) return(range_vals)
 
-  range_vals[1] <- min(0, lower)
+  # Keep barplots anchored at zero to avoid negative baselines when no annotations
+  range_vals[1] <- 0
   range_vals
 }
 
@@ -1412,6 +1413,22 @@ build_bar_plot_panel <- function(stats_df,
                                  posthoc_entry = NULL,
                                  nested_posthoc = NULL,
                                  y_limits = NULL) {
+
+  # Compute per-panel limits when not sharing axes so we can always anchor at zero
+  if (is.null(y_limits)) {
+    panel_range <- compute_barplot_panel_range(
+      stats_df,
+      factor1,
+      factor2,
+      posthoc_entry = posthoc_entry,
+      nested_posthoc = nested_posthoc
+    )
+
+    if (!is.null(panel_range)) {
+      y_limits <- expand_axis_limits(panel_range, lower_mult = 0, upper_mult = 0.12)
+      y_limits <- ensure_barplot_zero_baseline(y_limits)
+    }
+  }
 
   if (is.null(factor2) || !factor2 %in% names(stats_df)) {
     return(


### PR DESCRIPTION
## Summary
- compute per-panel barplot limits to consistently start at zero
- use axis expansion that preserves zero baseline even when annotations are present

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c777cc81c832bb5b84f71ec52491a)