### PR TITLE
Adjust descriptive plot titles

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -438,6 +438,7 @@ build_descriptive_categorical_plot <- function(df,
         theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label, fill = group_col) +
         theme(
+          plot.title = element_text(size = base_size, face = "bold", hjust = 0.5),
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
@@ -472,6 +473,7 @@ build_descriptive_categorical_plot <- function(df,
         theme_minimal(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label) +
         theme(
+          plot.title = element_text(size = base_size, face = "bold", hjust = 0.5),
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
@@ -506,7 +508,7 @@ build_descriptive_categorical_plot <- function(df,
   if (isTRUE(validation$valid)) {
     combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
       patchwork::plot_annotation(
-        theme = theme(plot.title = element_text(size = 16, face = "bold"))
+        theme = theme(plot.title = element_text(size = base_size, face = "bold", hjust = 0.5))
       )
 
     combined <- apply_common_legend_layout(

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -364,7 +364,7 @@ build_descriptive_numeric_boxplot <- function(df,
         geom_boxplot(outlier.shape = NA, width = 0.6) +
         scale_fill_manual(values = palette) +
         theme_minimal(base_size = base_size) +
-        labs(title = var, x = NULL, y = var) +
+        labs(x = NULL, y = var) +
         theme(
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
@@ -426,7 +426,7 @@ build_descriptive_numeric_boxplot <- function(df,
       p <- ggplot(df, aes(x = factor(1), y = .data[[var]])) +
         geom_boxplot(fill = single_color, width = 0.3) +
         theme_minimal(base_size = base_size) +
-        labs(title = var, x = NULL, y = var) +
+        labs(x = NULL, y = var) +
         theme(
           axis.text.x = element_blank(),
           axis.ticks.x = element_blank(),
@@ -502,10 +502,7 @@ build_descriptive_numeric_boxplot <- function(df,
 
   combined <- NULL
   if (isTRUE(validation$valid)) {
-    combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
-      patchwork::plot_annotation(
-        theme = theme(plot.title = element_text(size = 16, face = "bold"))
-      )
+    combined <- patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol)
 
     combined <- apply_common_legend_layout(
       combined,

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -374,7 +374,7 @@ build_descriptive_numeric_histogram <- function(df,
 
     base +
       theme_minimal(base_size = base_size) +
-      labs(title = var, x = var, y = y_label) +
+      labs(x = var, y = y_label) +
       theme(
         panel.grid.major = element_blank(),
         panel.grid.minor = element_blank(),
@@ -398,10 +398,7 @@ build_descriptive_numeric_histogram <- function(df,
 
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
   combined <- if (isTRUE(validation$valid)) {
-    patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol) +
-      patchwork::plot_annotation(
-        theme = theme(plot.title = element_text(size = 16, face = "bold"))
-      )
+    patchwork::wrap_plots(plots, nrow = layout$nrow, ncol = layout$ncol)
   } else {
     NULL
   }


### PR DESCRIPTION
## Summary
- Center and bold descriptive categorical plot titles to match ANOVA formatting
- Remove titles from numeric boxplots and histograms while keeping layouts intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c7a2e4630832bb89e674d0a97c3c8)