### PR TITLE
Ensure descriptive plots start axes at zero

### DIFF
--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -323,7 +323,7 @@ apply_value_scale <- function(plot, show_proportions, show_value_labels) {
   } else if (isTRUE(show_value_labels)) {
     plot + scale_y_continuous(limits = c(0, NA), expand = expansion(mult = c(0.05, 0.12)))
   } else {
-    plot
+    plot + scale_y_continuous(limits = c(0, NA), expand = expansion(mult = c(0, 0.05)))
   }
 }
 

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -375,6 +375,7 @@ build_descriptive_numeric_histogram <- function(df,
     base +
       theme_minimal(base_size = base_size) +
       labs(x = var, y = y_label) +
+      scale_y_continuous(limits = c(0, NA), expand = expansion(mult = c(0, 0.05))) +
       theme(
         panel.grid.major = element_blank(),
         panel.grid.minor = element_blank(),


### PR DESCRIPTION
## Summary
- start categorical barplot axes at zero even without value labels
- ensure numeric histograms anchor the count axis at zero for clearer comparisons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c7c57049c832b889bcb894b41fee1)