### PR TITLE
Align ANOVA plot axis labels with descriptive plots

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1488,7 +1488,7 @@ build_single_factor_barplot <- function(stats_df,
       axis.title.y = element_text(margin = margin(r = 6)),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      axis.text.x = element_text(angle = 0, hjust = 0.5),
+      axis.text.x = element_text(angle = 45, hjust = 1),
       axis.line = element_line(color = "gray30"),
       axis.ticks = element_line(color = "gray30")
     )
@@ -1558,7 +1558,7 @@ build_two_factor_barplot <- function(stats_df,
       axis.title.y = element_text(margin = margin(r = 6)),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      axis.text.x = element_text(angle = 0, hjust = 0.5),
+      axis.text.x = element_text(angle = 45, hjust = 1),
       axis.line = element_line(color = "gray30"),
       axis.ticks = element_line(color = "gray30")
     ) +


### PR DESCRIPTION
## Summary
- rotate ANOVA barplot x-axis labels to match the orientation used in descriptive plots for readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c82dd850c832bb77415b04f159e7c)