### PR TITLE
Apply unified plot theming

### DIFF
--- a/R/anova_shared.R
+++ b/R/anova_shared.R
@@ -1065,14 +1065,14 @@ build_line_plot_panel <- function(stats_df,
         width = 0.15,
         color = color_value
       ) +
-      theme_minimal(base_size = base_size) +
+      ta_plot_theme(base_size = base_size) +
       labs(x = factor1, y = "Mean ± SE") +
       theme(
         panel.grid.major = element_blank(),
         panel.grid.minor = element_blank(),
         axis.text.x = element_text(angle = 45, hjust = 1),
-        axis.line = element_line(color = "gray30"),
-        axis.ticks = element_line(color = "gray30")
+        axis.line = element_line(color = "#9ca3af"),
+        axis.ticks = element_line(color = "#9ca3af")
       )
   } else {
     group_levels <- if (is.factor(stats_df[[factor2]])) {
@@ -1141,7 +1141,7 @@ build_line_plot_panel <- function(stats_df,
     p <- p +
       point_layer +
       errorbar_layer +
-      theme_minimal(base_size = base_size) +
+      ta_plot_theme(base_size = base_size) +
       labs(
         x = factor1,
         y = "Mean ± SE",
@@ -1151,8 +1151,8 @@ build_line_plot_panel <- function(stats_df,
         panel.grid.major = element_blank(),
         panel.grid.minor = element_blank(),
         axis.text.x = element_text(angle = 45, hjust = 1),
-        axis.line = element_line(color = "gray30"),
-        axis.ticks = element_line(color = "gray30")
+        axis.line = element_line(color = "#9ca3af"),
+        axis.ticks = element_line(color = "#9ca3af")
       ) +
       scale_color_manual(values = palette)
   }
@@ -1351,7 +1351,7 @@ plot_anova_lineplot_meanse <- function(data,
       }
 
       title_plot <- ggplot() +
-        theme_void() +
+        ta_plot_theme_void() +
         ggtitle(resp) +
         theme(
           plot.title = element_text(
@@ -1482,7 +1482,7 @@ build_single_factor_barplot <- function(stats_df,
       color = "gray40",
       linewidth = 0.5
     ) +
-    theme_minimal(base_size = base_size) +
+    ta_plot_theme(base_size = base_size) +
     labs(x = factor1, y = "Mean ± SE", title = title_text) +
     theme(
       plot.title = element_text(size = base_size, face = "bold", hjust = 0.5),
@@ -1491,8 +1491,8 @@ build_single_factor_barplot <- function(stats_df,
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
       axis.text.x = element_text(angle = 45, hjust = 1),
-      axis.line = element_line(color = "gray30"),
-      axis.ticks = element_line(color = "gray30")
+      axis.line = element_line(color = "#9ca3af"),
+      axis.ticks = element_line(color = "#9ca3af")
     )
 
   expand_scale <- is.null(y_limits)
@@ -1552,7 +1552,7 @@ build_two_factor_barplot <- function(stats_df,
       color = "gray40",
       linewidth = 0.5
     ) +
-    theme_minimal(base_size = base_size) +
+    ta_plot_theme(base_size = base_size) +
     labs(x = factor1, y = "Mean ± SE", fill = factor2, title = title_text) +
     theme(
       plot.title = element_text(size = base_size, face = "bold", hjust = 0.5),
@@ -1561,8 +1561,8 @@ build_two_factor_barplot <- function(stats_df,
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
       axis.text.x = element_text(angle = 45, hjust = 1),
-      axis.line = element_line(color = "gray30"),
-      axis.ticks = element_line(color = "gray30")
+      axis.line = element_line(color = "#9ca3af"),
+      axis.ticks = element_line(color = "#9ca3af")
     ) +
     scale_fill_manual(values = palette)
 
@@ -2037,12 +2037,12 @@ plot_anova_barplot_meanse <- function(data,
           nrow = current_layout$nrow,
           ncol = current_layout$ncol
         )
-        
+
         title_plot <- ggplot() +
-          theme_void() +
+          ta_plot_theme_void() +
           ggtitle(resp) +
           theme(plot.title = element_text(size = base_size, face = "bold", hjust = 0.5))
-        
+
         response_plots[[resp]] <- title_plot / combined + patchwork::plot_layout(heights = c(0.08, 1))
       }
     } else {

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -435,15 +435,15 @@ build_descriptive_categorical_plot <- function(df,
       p <- ggplot(count_df, aes(x = .data[[var]], y = .data$value, fill = .data[[group_col]])) +
         geom_col(position = group_dodge, width = 0.65) +
         scale_fill_manual(values = palette) +
-        theme_minimal(base_size = base_size) +
+        ta_plot_theme(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label, fill = group_col) +
         theme(
           plot.title = element_text(size = base_size, face = "bold", hjust = 0.5),
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
-          axis.line = element_line(color = "gray30"),
-          axis.ticks = element_line(color = "gray30")
+          axis.line = element_line(color = "#9ca3af"),
+          axis.ticks = element_line(color = "#9ca3af")
         )
 
       p <- add_value_labels(p, count_df, show_value_labels, show_proportions, group_dodge, base_size)
@@ -470,15 +470,15 @@ build_descriptive_categorical_plot <- function(df,
 
       p <- ggplot(count_df, aes(x = .data[[var]], y = .data$value)) +
         geom_col(fill = single_fill, width = 0.65) +
-        theme_minimal(base_size = base_size) +
+        ta_plot_theme(base_size = base_size) +
         labs(title = var, x = NULL, y = y_label) +
         theme(
           plot.title = element_text(size = base_size, face = "bold", hjust = 0.5),
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
-          axis.line = element_line(color = "gray30"),
-          axis.ticks = element_line(color = "gray30")
+          axis.line = element_line(color = "#9ca3af"),
+          axis.ticks = element_line(color = "#9ca3af")
         )
 
       p <- add_value_labels(p, count_df, show_value_labels, show_proportions, base_size = base_size)

--- a/R/descriptive_visualize_metrics.R
+++ b/R/descriptive_visualize_metrics.R
@@ -184,16 +184,16 @@ build_metric_plot <- function(metric_info,
       geom_col(width = 0.65, fill = resolve_single_color(custom_colors)) +
       guides(fill = "none")
   }
-  
+
   p +
-    theme_minimal(base_size = base_size) +
+    ta_plot_theme(base_size = base_size) +
     labs(x = NULL, y = y_label, title = title) +
     theme(
       axis.text.x = element_text(angle = 45, hjust = 1),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      axis.line = element_line(color = "gray30"),
-      axis.ticks = element_line(color = "gray30")
+      axis.line = element_line(color = "#9ca3af"),
+      axis.ticks = element_line(color = "#9ca3af")
     )
 }
 

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -363,14 +363,14 @@ build_descriptive_numeric_boxplot <- function(df,
       p <- ggplot(df, aes(x = .data[[group_var]], y = .data[[var]], fill = .data[[group_var]])) +
         geom_boxplot(outlier.shape = NA, width = 0.6) +
         scale_fill_manual(values = palette) +
-        theme_minimal(base_size = base_size) +
+        ta_plot_theme(base_size = base_size) +
         labs(x = NULL, y = var) +
         theme(
           axis.text.x = element_text(angle = 45, hjust = 1),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
-          axis.line = element_line(color = "gray30"),
-          axis.ticks = element_line(color = "gray30")
+          axis.line = element_line(color = "#9ca3af"),
+          axis.ticks = element_line(color = "#9ca3af")
         )
 
       needs_color_scale <- FALSE
@@ -425,15 +425,15 @@ build_descriptive_numeric_boxplot <- function(df,
       single_color <- resolve_single_color(custom_colors)
       p <- ggplot(df, aes(x = factor(1), y = .data[[var]])) +
         geom_boxplot(fill = single_color, width = 0.3) +
-        theme_minimal(base_size = base_size) +
+        ta_plot_theme(base_size = base_size) +
         labs(x = NULL, y = var) +
         theme(
           axis.text.x = element_blank(),
           axis.ticks.x = element_blank(),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
-          axis.line = element_line(color = "gray30"),
-          axis.ticks = element_line(color = "gray30")
+          axis.line = element_line(color = "#9ca3af"),
+          axis.ticks = element_line(color = "#9ca3af")
         )
 
       if (isTRUE(show_points)) {

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -381,14 +381,14 @@ build_descriptive_numeric_histogram <- function(df,
     }
 
     base +
-      theme_minimal(base_size = base_size) +
+      ta_plot_theme(base_size = base_size) +
       labs(x = var, y = y_label) +
       scale_y_continuous(limits = c(0, NA), expand = expansion(mult = c(0, 0.05))) +
       theme(
         panel.grid.major = element_blank(),
         panel.grid.minor = element_blank(),
-        axis.line = element_line(color = "gray30"),
-        axis.ticks = element_line(color = "gray30")
+        axis.line = element_line(color = "#9ca3af"),
+        axis.ticks = element_line(color = "#9ca3af")
       )
   })
 

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -62,15 +62,13 @@ ggpairs_server <- function(id, data_reactive) {
           continuous = GGally::wrap("densityDiag", fill = basic_color_palette[1], alpha = 0.4)
         )
       ) +
-        ggplot2::theme_minimal(base_size = 11) +
+        ta_plot_theme(base_size = 11) +
         ggplot2::theme(
-          strip.text = ggplot2::element_text(face = "bold", size = 9),
-          panel.grid.minor = ggplot2::element_blank(),
+          strip.text = ggplot2::element_text(size = 9),
           panel.grid.major.x = ggplot2::element_blank(),
           panel.grid.major.y = ggplot2::element_blank(),
-          plot.title = ggplot2::element_text(size = 12, face = "bold"),
-          axis.line = ggplot2::element_line(color = "gray30"),
-          axis.ticks = ggplot2::element_line(color = "gray30")
+          axis.line = ggplot2::element_line(color = "#9ca3af"),
+          axis.ticks = ggplot2::element_line(color = "#9ca3af")
         )
     }
 

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -107,21 +107,21 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         lower = list(continuous = GGally::wrap("points", alpha = 0.6, colour = color, size = 1.5)),
         diag  = list(continuous = GGally::wrap("densityDiag", fill = color, alpha = 0.4))
       ) +
-        ggplot2::theme_minimal(base_size = base_size) +
+        ta_plot_theme(base_size = base_size) +
         ggplot2::theme(
-          strip.text = ggplot2::element_text(face = "bold", size = 9),
+          strip.text = ggplot2::element_text(size = 9),
           panel.grid.major = ggplot2::element_blank(),
           panel.grid.minor = ggplot2::element_blank(),
-          axis.line = ggplot2::element_line(color = "gray30"),
-          axis.ticks = ggplot2::element_line(color = "gray30")
+          axis.line = ggplot2::element_line(color = "#9ca3af"),
+          axis.ticks = ggplot2::element_line(color = "#9ca3af")
         )
-      
+
       if (!is.null(title)) p <- p + ggplot2::labs(title = title)
-      
+
       # wrap ggmatrix into a real ggplot object
       gtable <- GGally::ggmatrix_gtable(p)
       ggplot2::ggplot() +
-        ggplot2::theme_void() +
+        ta_plot_theme_void() +
         ggplot2::annotation_custom(
           grob = gtable,
           xmin = -Inf, xmax = Inf,

--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -328,7 +328,7 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
     build_message_panel <- function(title, message, show_title = TRUE) {
       has_title <- isTRUE(show_title) && !is.null(title) && nzchar(title)
       ggplot() +
-        theme_void() +
+        ta_plot_theme_void() +
         annotate("text", x = 0.5, y = 0.5, label = message, size = 4, hjust = 0.5, vjust = 0.5) +
         coord_cartesian(xlim = c(0, 1), ylim = c(0, 1), clip = "off") +
         labs(title = if (has_title) title else NULL) +
@@ -665,7 +665,7 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
       shape = if (is.null(shape_var)) 16 else NULL,
       color = if (is.null(color_var)) single_color else NULL
     ) +
-    theme_minimal(base_size = base_size) +
+    ta_plot_theme(base_size = base_size) +
     labs(
       x = x_lab,
       y = y_lab,
@@ -673,11 +673,10 @@ build_pca_biplot <- function(pca_obj, data, color_var = NULL, shape_var = NULL,
       shape = if (!is.null(shape_var)) shape_var else NULL
     ) +
     theme(
-      plot.title = element_text(size = 16, face = "bold"),
       panel.grid.major = element_blank(),
       panel.grid.minor = element_blank(),
-      axis.line = element_line(color = "gray30"),
-      axis.ticks = element_line(color = "gray30"),
+      axis.line = element_line(color = "#9ca3af"),
+      axis.ticks = element_line(color = "#9ca3af"),
       legend.position = "right"
     )
   

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -150,12 +150,12 @@ render_residual_plot <- function(model_obj) {
       x = "Fitted values",
       y = "Residuals"
     ) +
-    ggplot2::theme_minimal(base_size = 13) +
+    ta_plot_theme(base_size = 13) +
     ggplot2::theme(
       panel.grid.major = ggplot2::element_blank(),
       panel.grid.minor = ggplot2::element_blank(),
-      axis.line = ggplot2::element_line(color = "gray30"),
-      axis.ticks = ggplot2::element_line(color = "gray30")
+      axis.line = ggplot2::element_line(color = "#9ca3af"),
+      axis.ticks = ggplot2::element_line(color = "#9ca3af")
     )
 }
 
@@ -175,12 +175,12 @@ render_qq_plot <- function(model_obj) {
       x = "Theoretical quantiles",
       y = "Sample quantiles"
     ) +
-    ggplot2::theme_minimal(base_size = 13) +
+    ta_plot_theme(base_size = 13) +
     ggplot2::theme(
       panel.grid.major = ggplot2::element_blank(),
       panel.grid.minor = ggplot2::element_blank(),
-      axis.line = ggplot2::element_line(color = "gray30"),
-      axis.ticks = ggplot2::element_line(color = "gray30")
+      axis.line = ggplot2::element_line(color = "#9ca3af"),
+      axis.ticks = ggplot2::element_line(color = "#9ca3af")
     )
 }
 

--- a/R/submodule_theme.R
+++ b/R/submodule_theme.R
@@ -1,0 +1,34 @@
+# ===============================================================
+# 🎨 Shared plot theming utilities
+# ===============================================================
+
+# Consistent minimalist theme for Table Analyzer plots.
+ta_plot_theme <- function(base_size = 12) {
+  ggplot2::theme_minimal(base_size = base_size) +
+    ggplot2::theme(
+      plot.title = ggplot2::element_text(face = "bold", color = "#1f2d3d"),
+      plot.subtitle = ggplot2::element_text(color = "#4b5563"),
+      plot.caption = ggplot2::element_text(color = "#6b7280", size = ggplot2::rel(0.85)),
+      axis.title = ggplot2::element_text(face = "bold", color = "#111827"),
+      axis.text = ggplot2::element_text(color = "#1f2937"),
+      panel.grid.major = ggplot2::element_line(color = "#e5e7eb"),
+      panel.grid.minor = ggplot2::element_blank(),
+      strip.background = ggplot2::element_rect(fill = "#e5ecf6", color = NA),
+      strip.text = ggplot2::element_text(face = "bold", color = "#111827"),
+      legend.title = ggplot2::element_text(face = "bold"),
+      legend.background = ggplot2::element_rect(fill = "white", color = NA)
+    )
+}
+
+# Theme for plots that intentionally hide axes while keeping typographic harmony.
+ta_plot_theme_void <- function(base_size = 12) {
+  ggplot2::theme_void(base_size = base_size) +
+    ggplot2::theme(
+      plot.title = ggplot2::element_text(face = "bold", color = "#1f2d3d"),
+      plot.subtitle = ggplot2::element_text(color = "#4b5563"),
+      plot.caption = ggplot2::element_text(color = "#6b7280", size = ggplot2::rel(0.85)),
+      strip.text = ggplot2::element_text(face = "bold", color = "#111827"),
+      legend.title = ggplot2::element_text(face = "bold"),
+      legend.background = ggplot2::element_rect(fill = "white", color = NA)
+    )
+}


### PR DESCRIPTION
## Summary
- add shared plot theme helpers to keep visuals consistent across the app
- apply the shared theme to correlation, PCA, descriptive, ANOVA, and regression plots for aligned styling

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8504889c832b918176cd4fdf4f01)