### PR TITLE
Add apply control for descriptive visualization type

### DIFF
--- a/R/descriptive_visualize.R
+++ b/R/descriptive_visualize.R
@@ -26,6 +26,10 @@ visualize_descriptive_ui <- function(id) {
         ),
         "Choose the descriptive chart that best answers your question."
       ),
+      div(
+        class = "mb-3",
+        actionButton(ns("apply_plots"), "Apply changes", width = "100%")
+      ),
       uiOutput(ns("sub_controls"))
     ),
     mainPanel(
@@ -41,12 +45,16 @@ visualize_descriptive_ui <- function(id) {
 visualize_descriptive_server <- function(id, filtered_data, descriptive_summary) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    
-    # Active plot type
-    active_type <- reactive({
+
+    applied_type <- reactiveVal("categorical")
+
+    observeEvent(input$apply_plots, {
       req(input$plot_type)
-      input$plot_type
-    })
+      applied_type(input$plot_type)
+    }, ignoreInit = FALSE)
+
+    # Active plot type
+    active_type <- reactive(applied_type())
     
     # Always mount all submodules once (outputs suspended when hidden)
     visualize_categorical_barplots_server("categorical", filtered_data, descriptive_summary,


### PR DESCRIPTION
## Summary
- add an Apply changes button to the descriptive visualization panel
- activate the selected descriptive plot type only after the user applies the choice

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee584b140832b9d6a8abe938d0c91)