### PR TITLE
Use numeric-aware factor ordering for uploads

### DIFF
--- a/R/module_upload.R
+++ b/R/module_upload.R
@@ -305,7 +305,7 @@ upload_server <- function(id) {
       for (col in cols) {
         sel <- input[[paste0("type_", col)]] %||% "Numeric"
         if (sel == "Categorical") {
-          data[[col]] <- factor(as.character(data[[col]]))
+          data[[col]] <- auto_factor_order(as.character(data[[col]]))
         } else {
           data[[col]] <- suppressWarnings(as.numeric(as.character(data[[col]])))
         }

--- a/R/module_upload_helpers.R
+++ b/R/module_upload_helpers.R
@@ -1,19 +1,19 @@
 # Clean names + convert characters to ordered factors
 preprocess_uploaded_table <- function(df) {
-  df <- df |> mutate(across(where(is.character), auto_factor_order))
-  df
+  df |> mutate(across(where(is.character) | where(is.factor), auto_factor_order))
 }
 
-# Convert character to factor with numeric-aware order
+# Convert character/factor to factor with numeric-aware order
 auto_factor_order <- function(x) {
-  if (!is.character(x)) return(x)
-  nums <- suppressWarnings(as.numeric(gsub("\\D", "", x)))
-  if (all(is.na(nums))) {
-    factor(x, levels = sort(unique(x)))
-  } else {
-    x <- factor(x, levels = unique(x[order(nums, na.last = TRUE)]))
-    x
-  }
+  if (!is.factor(x) && !is.character(x)) return(x)
+
+  ordered_levels <- stringr::str_sort(
+    if (is.factor(x)) levels(x) else unique(x),
+    numeric = TRUE,
+    na_last = TRUE
+  )
+
+  factor(x, levels = ordered_levels, ordered = is.ordered(x))
 }
 
 

--- a/tests/test_preprocess_uploaded_table.R
+++ b/tests/test_preprocess_uploaded_table.R
@@ -33,7 +33,7 @@ test_that("preprocess_uploaded_table cleans column names and orders factors", {
 })
 
 test_that("preprocess_uploaded_table handles all-character dataframes", {
-  
+
   df <- tibble(
     ColA = c("x", "y", "z"),
     ColB = c("10", "2", "30")
@@ -44,6 +44,19 @@ test_that("preprocess_uploaded_table handles all-character dataframes", {
   expect_s3_class(out, "tbl_df")
   expect_true(all(sapply(out, is.factor)))
   expect_equal(names(out), c("col_a", "col_b"))
+})
+
+test_that("auto_factor_order reorders factors with numeric-aware sorting", {
+
+  df <- tibble(
+    Letter = factor(c("B", "A"), levels = c("B", "A")),
+    Mix    = c("v10", "v2", "v1")
+  )
+
+  out <- preprocess_uploaded_table(df)
+
+  expect_equal(levels(out$Letter), c("A", "B"))
+  expect_equal(levels(out$Mix), c("v1", "v2", "v10"))
 })
 
 test_that("preprocess_uploaded_table handles numeric-only dataframes", {


### PR DESCRIPTION
## Summary
- relevel all character and factor columns with numeric-aware sorting during upload preprocessing
- apply the same ordering when users convert ambiguous numeric columns to categorical
- add coverage for numeric-aware factor reordering

## Testing
- Not run (Rscript not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef584cf4c832b90190cdf1e0610ce)