### PR TITLE
Remove bar value label toggles

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -22,11 +22,6 @@ visualize_oneway_ui <- function(id) {
       ),
       
       conditionalPanel(
-        condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
-        checkboxInput(ns("show_bar_labels"), "Show value labels on bars", value = FALSE)
-      ),
-      
-      conditionalPanel(
         condition = sprintf("input['%s'] === 'lineplot_mean_se'", ns("plot_type")),
         fluidRow(
           column(6, checkboxInput(ns("lineplot_show_lines"),  "Connect means with lines", value = TRUE)),
@@ -127,7 +122,6 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
           data, info,
           layout_values     = layout_inputs,
           line_colors       = custom_colors(),
-          show_value_labels = input$show_bar_labels,
           base_size         = base_size(),
           posthoc_all       = info$posthoc,
           share_y_axis      = input$share_y_axis

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -23,17 +23,6 @@ visualize_twoway_ui <- function(id) {
         "Pick the chart style you prefer for viewing group means and uncertainty."
       ),
       conditionalPanel(
-        condition = sprintf("input['%s'] === 'barplot_mean_se'", ns("plot_type")),
-        with_help_tooltip(
-          checkboxInput(
-            ns("show_bar_labels"),
-            "Show value labels on bars",
-            value = FALSE
-          ),
-          "Turn on labels to display the mean value on each bar."
-        )
-      ),
-      conditionalPanel(
         condition = sprintf("input['%s'] === 'lineplot_mean_se'", ns("plot_type")),
         fluidRow(
           column(
@@ -273,7 +262,6 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
         barplot_mean_se = plot_anova_barplot_meanse(
           data, info, layout_inputs,
           line_colors       = custom_colors(),
-          show_value_labels = input$show_bar_labels,
           base_size         = base_size(),
           posthoc_all       = info$posthoc,
           share_y_axis      = input$share_y_axis,


### PR DESCRIPTION
## Summary
- remove the bar value label UI controls from descriptive and ANOVA visualization panels
- simplify categorical barplot scaling now that labels are not displayed
- streamline ANOVA barplot helpers by removing label-rendering paths

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f24185b7c832ba816efb1ed30619d)