### PR TITLE
Initialize grid controls with computed defaults

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -129,10 +129,27 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       )
       
       chosen <- input$plot_type
-      
-      stored$warning <- results[[chosen]]$warning
-      stored$plot    <- results[[chosen]]$plot
-      stored$layout  <- results[[chosen]]$layout
+      chosen_result <- results[[chosen]]
+
+      stored$warning <- chosen_result$warning
+      stored$plot    <- chosen_result$plot
+      stored$layout  <- chosen_result$layout
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "strata_grid",
+        chosen_result$defaults$strata,
+        n_items = chosen_result$panel_counts$strata
+      )
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "response_grid",
+        chosen_result$defaults$responses,
+        n_items = chosen_result$panel_counts$responses
+      )
     })
     
     output$plot_warning <- renderUI({

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -271,10 +271,27 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       )
       
       chosen <- input$plot_type
-      
-      stored$warning <- results[[chosen]]$warning
-      stored$plot    <- results[[chosen]]$plot
-      stored$layout  <- results[[chosen]]$layout
+      chosen_result <- results[[chosen]]
+
+      stored$warning <- chosen_result$warning
+      stored$plot    <- chosen_result$plot
+      stored$layout  <- chosen_result$layout
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "strata_grid",
+        chosen_result$defaults$strata,
+        n_items = chosen_result$panel_counts$strata
+      )
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "response_grid",
+        chosen_result$defaults$responses,
+        n_items = chosen_result$panel_counts$responses
+      )
     })
     
     # ------------------------------------------------------------------

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -171,10 +171,18 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         common_legend = legend_state$enabled,
         legend_position = if (legend_state$enabled) legend_state$position else NULL
       )
-      
+
       stored$plot    <- res$plot
       stored$warning <- res$warning
       stored$layout  <- res$layout
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        res$defaults,
+        n_items = res$panels
+      )
     })
     
     # -------------------------

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -214,10 +214,18 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         common_legend = legend_state$enabled,
         legend_position = if (legend_state$enabled) legend_state$position else NULL
       )
-      
+
       stored$plot    <- res$plot
       stored$layout  <- res$layout
       stored$warning <- res$warning
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        res$defaults,
+        n_items = res$panels
+      )
     })
     
     #======================================================

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -180,10 +180,18 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
         common_legend = legend_state$enabled,
         legend_position = if (legend_state$enabled) legend_state$position else NULL
       )
-      
+
       stored$plot    <- res$plot
       stored$layout  <- res$layout
       stored$warning <- res$warning
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        res$defaults,
+        n_items = res$panels
+      )
     })
     
     # ================================================================


### PR DESCRIPTION
## Summary
- populate visualization grid controls with the default layouts used to render their plots
- synchronize ANOVA grid inputs with the computed strata and response layouts
- keep descriptive plot grid inputs aligned with the panel counts driving each plot

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f25c19864832bac9ff3fe4b59afa4)