### PR TITLE
Prefill grid controls before applying changes

### DIFF
--- a/R/anova_oneway_visualize.R
+++ b/R/anova_oneway_visualize.R
@@ -82,12 +82,48 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
     
     strata_grid   <- plot_grid_server("strata_grid")
     response_grid <- plot_grid_server("response_grid")
-    
+
     output$layout_controls <- renderUI({
       info <- model_info()
       req(info)
       build_anova_layout_controls(ns, input, info)
     })
+
+    prefill_grid_defaults <- function() {
+      data <- df()
+      info <- model_info()
+
+      if (is.null(info) || is.null(data) || nrow(data) == 0) return()
+
+      layout_inputs <- list(
+        strata_rows = strata_grid$rows(),
+        strata_cols = strata_grid$cols(),
+        resp_rows   = response_grid$rows(),
+        resp_cols   = response_grid$cols()
+      )
+
+      context <- initialize_anova_plot_context(data, info, layout_inputs)
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "strata_grid",
+        context$strata_defaults,
+        n_items = context$n_expected_strata
+      )
+
+      response_defaults <- compute_default_grid(length(context$responses %||% character()))
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "response_grid",
+        response_defaults,
+        n_items = length(context$responses %||% character())
+      )
+    }
+
+    observeEvent(list(df(), model_info()), prefill_grid_defaults(), ignoreNULL = TRUE)
     
     observeEvent(input$apply_plot, {
       data <- df()
@@ -129,10 +165,27 @@ visualize_oneway_server <- function(id, filtered_data, model_info) {
       )
       
       chosen <- input$plot_type
-      
-      stored$warning <- results[[chosen]]$warning
-      stored$plot    <- results[[chosen]]$plot
-      stored$layout  <- results[[chosen]]$layout
+      chosen_result <- results[[chosen]]
+
+      stored$warning <- chosen_result$warning
+      stored$plot    <- chosen_result$plot
+      stored$layout  <- chosen_result$layout
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "strata_grid",
+        chosen_result$defaults$strata,
+        n_items = chosen_result$panel_counts$strata
+      )
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "response_grid",
+        chosen_result$defaults$responses,
+        n_items = chosen_result$panel_counts$responses
+      )
     })
     
     output$plot_warning <- renderUI({

--- a/R/anova_twoway_visualize.R
+++ b/R/anova_twoway_visualize.R
@@ -126,13 +126,49 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
     
     strata_grid <- plot_grid_server("strata_grid")
     response_grid <- plot_grid_server("response_grid")
-    
+
     # UI render
     output$layout_controls <- renderUI({
       info <- model_info()
       req(info)
       build_anova_layout_controls(ns, input, info)
     })
+
+    prefill_grid_defaults <- function() {
+      data <- df()
+      info <- model_info()
+
+      if (is.null(info) || is.null(data) || nrow(data) == 0) return()
+
+      layout_inputs <- list(
+        strata_rows = strata_grid$rows(),
+        strata_cols = strata_grid$cols(),
+        resp_rows   = response_grid$rows(),
+        resp_cols   = response_grid$cols()
+      )
+
+      context <- initialize_anova_plot_context(data, info, layout_inputs)
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "strata_grid",
+        context$strata_defaults,
+        n_items = context$n_expected_strata
+      )
+
+      response_defaults <- compute_default_grid(length(context$responses %||% character()))
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "response_grid",
+        response_defaults,
+        n_items = length(context$responses %||% character())
+      )
+    }
+
+    observeEvent(list(df(), model_info()), prefill_grid_defaults(), ignoreNULL = TRUE)
     
     output$axis_and_jitter <- renderUI({
       jitter_widget <- NULL
@@ -271,10 +307,27 @@ visualize_twoway_server <- function(id, filtered_data, model_info) {
       )
       
       chosen <- input$plot_type
-      
-      stored$warning <- results[[chosen]]$warning
-      stored$plot    <- results[[chosen]]$plot
-      stored$layout  <- results[[chosen]]$layout
+      chosen_result <- results[[chosen]]
+
+      stored$warning <- chosen_result$warning
+      stored$plot    <- chosen_result$plot
+      stored$layout  <- chosen_result$layout
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "strata_grid",
+        chosen_result$defaults$strata,
+        n_items = chosen_result$panel_counts$strata
+      )
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "response_grid",
+        chosen_result$defaults$responses,
+        n_items = chosen_result$panel_counts$responses
+      )
     })
     
     # ------------------------------------------------------------------

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -92,6 +92,65 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
     custom_colors <- add_color_customization_server(
       ns, input, output, df, color_var, multi_group = TRUE
     )
+
+    prefill_grid_defaults <- function() {
+      data <- df()
+      info <- summary_info()
+
+      if (is.null(data) || is.null(info) || nrow(data) == 0) return()
+
+      s_vars <- resolve_reactive(info$selected_vars)
+      g_var  <- resolve_reactive(info$group_var)
+      strata_levels <- resolve_reactive(info$strata_levels)
+      processed <- resolve_reactive(info$processed_data)
+
+      dat <- if (!is.null(processed)) processed else data
+
+      factor_vars <- names(dat)[vapply(dat, function(x) {
+        is.character(x) || is.factor(x) || is.logical(x)
+      }, logical(1))]
+
+      if (!is.null(s_vars) && length(s_vars) > 0) {
+        factor_vars <- intersect(factor_vars, s_vars)
+      }
+      if (length(factor_vars) == 0) return()
+
+      if (!is.null(g_var) && g_var %in% names(dat)) {
+        dat[[g_var]] <- as.character(dat[[g_var]])
+        dat[[g_var]][is.na(dat[[g_var]]) | trimws(dat[[g_var]]) == ""] <- "Missing"
+
+        if (!is.null(strata_levels) && length(strata_levels) > 0) {
+          keep_levels <- unique(strata_levels)
+          dat <- dat[dat[[g_var]] %in% keep_levels, , drop = FALSE]
+          if (nrow(dat) == 0) return()
+          dat[[g_var]] <- factor(dat[[g_var]], levels = keep_levels)
+        } else {
+          dat[[g_var]] <- factor(dat[[g_var]], levels = unique(dat[[g_var]]))
+        }
+      } else {
+        g_var <- NULL
+      }
+
+      has_data <- vapply(factor_vars, function(var) {
+        cols <- intersect(c(var, g_var), names(dat))
+        var_data <- dat[, cols, drop = FALSE]
+        var_data[[var]] <- as.character(var_data[[var]])
+        any(!is.na(var_data[[var]]) & trimws(var_data[[var]]) != "")
+      }, logical(1))
+
+      n_panels <- sum(has_data)
+      if (n_panels == 0) return()
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        compute_default_grid(n_panels),
+        n_items = n_panels
+      )
+    }
+
+    observeEvent(list(df(), summary_info()), prefill_grid_defaults(), ignoreNULL = TRUE)
     
     # --------------------------
     # Common legend logic
@@ -171,10 +230,18 @@ visualize_categorical_barplots_server <- function(id, filtered_data, summary_inf
         common_legend = legend_state$enabled,
         legend_position = if (legend_state$enabled) legend_state$position else NULL
       )
-      
+
       stored$plot    <- res$plot
       stored$warning <- res$warning
       stored$layout  <- res$layout
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        res$defaults,
+        n_items = res$panels
+      )
     })
     
     # -------------------------

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -136,6 +136,43 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
     custom_colors <- add_color_customization_server(
       ns, input, output, df, color_var, multi_group = TRUE
     )
+
+    prefill_grid_defaults <- function() {
+      data <- df()
+      info <- summary_info()
+
+      if (is.null(data) || is.null(info) || nrow(data) == 0) return()
+
+      s_vars <- resolve_reactive(info$selected_vars)
+      processed <- resolve_reactive(info$processed_data)
+      dat <- if (!is.null(processed)) processed else data
+
+      num_vars <- names(dat)[vapply(dat, is.numeric, logical(1))]
+      if (!is.null(s_vars) && length(s_vars) > 0) {
+        num_vars <- intersect(num_vars, s_vars)
+      }
+      if (length(num_vars) == 0) return()
+
+      has_data <- vapply(num_vars, function(var) {
+        vec <- dat[[var]]
+        any(!is.na(vec))
+      }, logical(1))
+
+      n_panels <- sum(has_data)
+      if (n_panels == 0) return()
+
+      defaults <- list(rows = 1L, cols = max(1L, as.integer(n_panels)))
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        defaults,
+        n_items = n_panels
+      )
+    }
+
+    observeEvent(list(df(), summary_info()), prefill_grid_defaults(), ignoreNULL = TRUE)
     
     #======================================================
     # Common legend toggle
@@ -214,10 +251,18 @@ visualize_numeric_boxplots_server <- function(id, filtered_data, summary_info, i
         common_legend = legend_state$enabled,
         legend_position = if (legend_state$enabled) legend_state$position else NULL
       )
-      
+
       stored$plot    <- res$plot
       stored$layout  <- res$layout
       stored$warning <- res$warning
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        res$defaults,
+        n_items = res$panels
+      )
     })
     
     #======================================================

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -142,6 +142,56 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
       
       tagList(checkbox, pos)
     })
+
+    prefill_grid_defaults <- function() {
+      data <- df()
+      info <- summary_info()
+
+      if (is.null(data) || is.null(info) || nrow(data) == 0) return()
+
+      s_vars <- resolve_reactive(info$selected_vars)
+      g_var  <- resolve_reactive(info$group_var)
+      strata_levels <- resolve_reactive(info$strata_levels)
+
+      processed <- resolve_reactive(info$processed_data)
+      dat <- if (!is.null(processed)) processed else data
+
+      num_vars <- names(Filter(is.numeric, dat))
+      if (!is.null(s_vars) && length(s_vars) > 0) {
+        num_vars <- intersect(num_vars, s_vars)
+      }
+      if (length(num_vars) == 0) return()
+
+      valid_panels <- vapply(num_vars, function(var) {
+        cols <- intersect(c(var, g_var), names(dat))
+        plot_data <- dat[, cols, drop = FALSE]
+
+        if (!is.null(g_var)) {
+          plot_data[[g_var]] <- as.character(plot_data[[g_var]])
+          if (!is.null(strata_levels) && length(strata_levels) > 0) {
+            keep_levels <- unique(strata_levels)
+            plot_data <- plot_data[plot_data[[g_var]] %in% keep_levels, , drop = FALSE]
+          }
+        }
+
+        keep <- is.finite(plot_data[[var]])
+        keep[is.na(keep)] <- FALSE
+        any(keep)
+      }, logical(1))
+
+      n_panels <- sum(valid_panels)
+      if (n_panels == 0) return()
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        compute_default_grid(n_panels),
+        n_items = n_panels
+      )
+    }
+
+    observeEvent(list(df(), summary_info()), prefill_grid_defaults(), ignoreNULL = TRUE)
     
     # ================================================================
     # APPLY — compute histogram only when user clicks
@@ -180,10 +230,18 @@ visualize_numeric_histograms_server <- function(id, filtered_data, summary_info,
         common_legend = legend_state$enabled,
         legend_position = if (legend_state$enabled) legend_state$position else NULL
       )
-      
+
       stored$plot    <- res$plot
       stored$layout  <- res$layout
       stored$warning <- res$warning
+
+      apply_grid_defaults_if_empty(
+        input,
+        session,
+        "plot_grid",
+        res$defaults,
+        n_items = res$panels
+      )
     })
     
     # ================================================================


### PR DESCRIPTION
## Summary
- prefill descriptive histogram, boxplot, and categorical grid controls with the computed default layouts when data loads
- initialize ANOVA strata and response grid inputs to their expected layouts without requiring Apply
- keep grid inputs aligned with panel counts even before rendering plots

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f25c19864832bac9ff3fe4b59afa4)