### PR TITLE
Adjust plot grid layout to panel count

### DIFF
--- a/R/submodule_plot_grid.R
+++ b/R/submodule_plot_grid.R
@@ -93,13 +93,28 @@ apply_grid_defaults_if_empty <- function(input, session, grid_id, defaults, n_it
 
 adjust_grid_layout <- function(n_items, layout) {
   if (is.null(layout) || length(layout) == 0) {
-    return(list(nrow = 1L, ncol = 1L))
+    layout <- list(nrow = 1L, ncol = 1L)
   }
-  
-  list(
-    nrow = as.integer(layout$nrow),
-    ncol = as.integer(layout$ncol)
-  )
+
+  n_items <- coerce_grid_value(n_items, default = 1L)
+  rows <- coerce_grid_value(layout$nrow, default = 1L)
+  cols <- coerce_grid_value(layout$ncol, default = 1L)
+
+  if (rows * cols < n_items) {
+    defaults <- compute_default_grid(n_items)
+    rows <- defaults$rows
+    cols <- defaults$cols
+  }
+
+  while (rows > 1L && n_items <= (rows - 1L) * cols) {
+    rows <- rows - 1L
+  }
+
+  while (cols > 1L && n_items <= rows * (cols - 1L)) {
+    cols <- cols - 1L
+  }
+
+  list(nrow = rows, ncol = cols)
 }
 
 plot_grid_ui <- function(id,


### PR DESCRIPTION
## Summary
- make plot grid adjustment clamp to the current number of panels so stale layouts are corrected automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f30a9e508832b9ff5fdd1fe529096)