### PR TITLE
Stop auto-adjusting plot grids

### DIFF
--- a/R/anova_shared_barplots.R
+++ b/R/anova_shared_barplots.R
@@ -86,11 +86,10 @@ plot_anova_barplot_meanse <- function(data,
       
       if (length(stratum_plots) > 0) {
         strata_panel_count <- max(strata_panel_count, length(stratum_plots))
-        current_layout <- adjust_grid_layout(length(stratum_plots), context$strata_layout)
         combined <- patchwork::wrap_plots(
           plotlist = stratum_plots,
-          nrow = current_layout$nrow,
-          ncol = current_layout$ncol
+          nrow = context$strata_layout$nrow,
+          ncol = context$strata_layout$ncol
         )
 
         title_plot <- ggplot() +

--- a/R/anova_shared_lineplots.R
+++ b/R/anova_shared_lineplots.R
@@ -86,13 +86,11 @@ plot_anova_lineplot_meanse <- function(data,
           use_dodge = use_dodge
         )
       })
-      
-      current_layout <- adjust_grid_layout(length(stratum_stats), context$strata_layout)
-      
+
       combined <- patchwork::wrap_plots(
         plotlist = strata_plot_list,
-        nrow = current_layout$nrow,
-        ncol = current_layout$ncol
+        nrow = context$strata_layout$nrow,
+        ncol = context$strata_layout$ncol
       )
       
       if (isTRUE(common_legend)) {

--- a/R/anova_shared_plot_context.R
+++ b/R/anova_shared_plot_context.R
@@ -137,11 +137,7 @@ finalize_anova_plot_result <- function(response_plots,
   if (has_strata && strata_panel_count == 0L) {
     strata_panel_count <- context$n_expected_strata
   }
-  
-  if (has_strata) {
-    strata_layout <- adjust_grid_layout(max(1L, strata_panel_count), strata_layout)
-  }
-  
+
   response_defaults <- compute_default_grid(length(response_plots))
   response_layout <- basic_grid_layout(
     rows = context$layout_input$resp_rows,
@@ -149,8 +145,7 @@ finalize_anova_plot_result <- function(response_plots,
     default_rows = response_defaults$rows,
     default_cols = response_defaults$cols
   )
-  response_layout <- adjust_grid_layout(length(response_plots), response_layout)
-  
+
   strata_validation <- if (has_strata) {
     validate_grid(max(1L, strata_panel_count), strata_layout$nrow, strata_layout$ncol)
   } else {

--- a/R/descriptive_visualize_categorical_barplots.R
+++ b/R/descriptive_visualize_categorical_barplots.R
@@ -398,8 +398,6 @@ build_descriptive_categorical_plot <- function(df,
     default_cols = defaults$cols
   )
 
-  layout <- adjust_grid_layout(n_panels, layout)
-
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
 
   combined <- NULL

--- a/R/descriptive_visualize_numeric_boxplots.R
+++ b/R/descriptive_visualize_numeric_boxplots.R
@@ -456,8 +456,6 @@ build_descriptive_numeric_boxplot <- function(df,
     max_cols = max(100L, as.integer(defaults$cols))
   )
 
-  layout <- adjust_grid_layout(n_panels, layout)
-
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
 
   combined <- NULL

--- a/R/descriptive_visualize_numeric_histograms.R
+++ b/R/descriptive_visualize_numeric_histograms.R
@@ -363,7 +363,6 @@ build_descriptive_numeric_histogram <- function(df,
     default_rows = defaults$rows,
     default_cols = defaults$cols
   )
-  layout <- adjust_grid_layout(n_panels, layout)
 
   validation <- validate_grid(n_panels, layout$nrow, layout$ncol)
   combined <- if (isTRUE(validation$valid)) {

--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -190,7 +190,6 @@ pairwise_correlation_visualize_ggpairs_server <- function(
         default_rows = defaults$rows,
         default_cols = defaults$cols
       )
-      layout <- adjust_grid_layout(n_panels, layout)
       val <- validate_grid(n_panels, layout$nrow, layout$ncol)
       
       combined <- NULL


### PR DESCRIPTION
## Summary
- stop auto-correcting grid layouts across visualization modules so invalid inputs show warnings
- rely on grid validation to block plot rendering when rows/cols are too small or too large
- keep layout defaults unchanged while respecting user-specified grid sizes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220b71c5f4832b99f2dc0dc89b7395)