### PR TITLE
Prevent duplicate factor selection in two-way ANOVA

### DIFF
--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -109,6 +109,10 @@ two_way_anova_server <- function(id, filtered_data) {
       resp_vals <- responses()
       validate(
         need(length(resp_vals) > 0, "Please select at least one response variable."),
+        need(
+          !identical(input$factor1, input$factor2),
+          "Categorical predictor 1 and 2 must be different variables."
+        ),
         need(all(input$order1 %in% unique(df[[input$factor1]])), "Invalid level order for first factor."),
         need(all(input$order2 %in% unique(df[[input$factor2]])), "Invalid level order for second factor.")
       )


### PR DESCRIPTION
## Summary
- add validation to ensure the two categorical predictors in the two-way ANOVA are different
- surface an in-app error message consistent with existing validation messaging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ea968048832b9a4d7cf6cbfaaf19)