### PR TITLE
Include contrast tables in ANOVA docx exports

### DIFF
--- a/R/anova_shared_results.R
+++ b/R/anova_shared_results.R
@@ -148,6 +148,7 @@ download_all_anova_results <- function(models_info, file) {
   }
 
   combined_results <- list()
+  contrast_results <- list()
   factor_names <- unique(unlist(models_info$factors))
   factor_names <- factor_names[!is.na(factor_names) & nzchar(factor_names)]
   errors <- character(0)
@@ -180,6 +181,13 @@ download_all_anova_results <- function(models_info, file) {
       names(tbl) <- sub(" ", "", names(tbl))
       tbl$PrF <- tbl[, grep("^Pr", names(tbl))[1]]
       combined_results[[length(combined_results) + 1]] <- tbl
+
+      if (!is.null(outputs$posthoc_table)) {
+        contrast_tbl <- outputs$posthoc_table
+        contrast_tbl$Response <- resp
+        contrast_tbl$Stratum <- "None"
+        contrast_results[[length(contrast_results) + 1]] <- contrast_tbl
+      }
     }
   } else {
     # --- Case 2: stratified
@@ -210,11 +218,18 @@ download_all_anova_results <- function(models_info, file) {
         names(tbl) <- sub(" ", "", names(tbl))
         tbl$PrF <- tbl[, grep("^Pr", names(tbl))[1]]
         combined_results[[length(combined_results) + 1]] <- tbl
+
+        if (!is.null(outputs$posthoc_table)) {
+          contrast_tbl <- outputs$posthoc_table
+          contrast_tbl$Response <- resp
+          contrast_tbl$Stratum <- stratum
+          contrast_results[[length(contrast_results) + 1]] <- contrast_tbl
+        }
       }
     }
   }
 
-  if (length(combined_results) == 0) {
+  if (length(combined_results) == 0 && length(contrast_results) == 0) {
     msg <- "No ANOVA models available to export."
     if (length(errors) > 0) {
       msg <- paste0(
@@ -226,18 +241,27 @@ download_all_anova_results <- function(models_info, file) {
     stop(msg)
   }
 
-  write_anova_docx(combined_results, file)
+  write_anova_docx(
+    file = file,
+    content = list(anova = combined_results, contrasts = contrast_results)
+  )
 }
 
-write_anova_docx <- function(results, file) {
+write_anova_docx <- function(file, content, response_name = NULL, stratum_label = NULL) {
 
-  if (is.null(results) || length(results) == 0) stop("No ANOVA results available to export.")
-  combined <- bind_rows(results)
-  
+  prep <- prepare_docx_tables(content, response_name, stratum_label)
+  combined_anova <- prep$anova
+  combined_contrasts <- prep$contrasts
+
+  if (is.null(combined_anova) || length(combined_anova) == 0) {
+    stop("No ANOVA results available to export.")
+  }
+
+  combined <- bind_rows(combined_anova)
+
   required_cols <- c("Response", "Stratum", "Term", "SumSq", "Df", "Fvalue", "PrF")
   if (!all(required_cols %in% names(combined))) stop("Missing required columns in ANOVA results.")
-  
-  # Format and sort
+
   combined <- combined %>%
     mutate(
       SumSq = round(SumSq, 3),
@@ -246,8 +270,7 @@ write_anova_docx <- function(results, file) {
       sig = PrF < 0.05
     ) %>%
     arrange(Response, Stratum, Term)
-  
-  # Hide Stratum column if it's all "None"
+
   if (length(unique(combined$Stratum)) == 1 && unique(combined$Stratum) == "None") {
     combined$Stratum <- NULL
     visible_cols <- c("Response", "Term", "SumSq", "Df", "Fvalue", "PrF_label")
@@ -256,11 +279,8 @@ write_anova_docx <- function(results, file) {
     visible_cols <- c("Response", "Stratum", "Term", "SumSq", "Df", "Fvalue", "PrF_label")
     merge_cols <- c("Response", "Stratum")
   }
-  
-  # Build flextable
+
   ft <- flextable(combined[, visible_cols])
-  
-  # Clean header names
   ft <- set_header_labels(
     ft,
     Response = "Response",
@@ -271,58 +291,161 @@ write_anova_docx <- function(results, file) {
     Fvalue = "F value",
     PrF_label = "Pr(>F)"
   )
-  
-  # Merge identical group labels
-  ft <- merge_v(ft, j = intersect(merge_cols, ft$col_keys))
-  
-  # Styling
-  ft <- fontsize(ft, part = "all", size = 10)
-  ft <- bold(ft, part = "header", bold = TRUE)
-  ft <- color(ft, part = "header", color = "black")
-  ft <- align(ft, align = "center", part = "all")
-  
-  # Bold significant p-values (< 0.05)
-  if ("sig" %in% names(combined)) {
-    sig_rows <- which(combined$sig)
-    if (length(sig_rows) > 0 && "PrF_label" %in% ft$col_keys) {
-      ft <- bold(ft, i = sig_rows, j = "PrF_label", bold = TRUE)
-    }
-  }
-  
-  # Journal-style borders
-  ft <- border_remove(ft)
-  black <- fp_border(color = "black", width = 1)
-  thin <- fp_border(color = "black", width = 0.5)
-  
-  # 1) Top line above header
-  ft <- border(ft, part = "header", border.top = black)
-  # 2) Line below header
-  ft <- border(ft, part = "header", border.bottom = black)
-  
-  # 3) Thin horizontal lines between different responses
-  if ("Response" %in% names(combined)) {
-    resp_index <- which(diff(as.numeric(factor(combined$Response))) != 0)
-    if (length(resp_index) > 0) {
-      ft <- border(ft, i = resp_index, part = "body", border.bottom = thin)
-    }
-  }
-  
-  # 4) Final bottom border (last line)
-  if (nrow(combined) > 0) {
-    ft <- border(ft, i = nrow(combined), part = "body", border.bottom = black)
-  }
-  
-  
-  # No side or inner borders
-  ft <- set_table_properties(ft, layout = "autofit", width = 0.9)
-  ft <- padding(ft, padding.top = 2, padding.bottom = 2, padding.left = 2, padding.right = 2)
-  
-  # Write to DOCX
+
+  ft <- apply_publication_style(ft, combined, merge_cols, which(combined$sig), "PrF_label")
+
   doc <- read_docx()
+  doc <- body_add_par(doc, "Type III ANOVA", style = "heading 1")
   doc <- body_add_flextable(doc, ft)
+
+  if (!is.null(combined_contrasts) && length(combined_contrasts) > 0) {
+    contrast_df <- bind_rows(combined_contrasts)
+    contrast_df <- format_contrast_table(contrast_df)
+
+    if (!is.null(contrast_df)) {
+      if (!"Stratum" %in% names(contrast_df) ||
+        (length(unique(contrast_df$Stratum)) == 1 && unique(contrast_df$Stratum) == "None")) {
+        contrast_df$Stratum <- NULL
+        c_visible_cols <- c("Response", "Factor", "contrast", "estimate", "SE", "df", "t.ratio", "lower.CL", "upper.CL", "p_label")
+        c_merge_cols <- c("Response")
+      } else {
+        c_visible_cols <- c("Response", "Stratum", "Factor", "contrast", "estimate", "SE", "df", "t.ratio", "lower.CL", "upper.CL", "p_label")
+        c_merge_cols <- c("Response", "Stratum")
+      }
+
+      c_visible_cols <- intersect(c_visible_cols, names(contrast_df))
+      contrast_ft <- flextable(contrast_df[, c_visible_cols])
+      contrast_ft <- set_header_labels(
+        contrast_ft,
+        Response = "Response",
+        Stratum = if ("Stratum" %in% c_visible_cols) "Stratum" else NULL,
+        Factor = if ("Factor" %in% c_visible_cols) "Factor" else NULL,
+        contrast = "Contrast",
+        estimate = "Estimate",
+        SE = "SE",
+        df = "df",
+        t.ratio = "t-ratio",
+        lower.CL = if ("lower.CL" %in% c_visible_cols) "Lower CL" else NULL,
+        upper.CL = if ("upper.CL" %in% c_visible_cols) "Upper CL" else NULL,
+        p_label = "p-value"
+      )
+
+      contrast_ft <- apply_publication_style(
+        contrast_ft,
+        contrast_df,
+        c_merge_cols,
+        which(contrast_df$sig),
+        "p_label"
+      )
+
+      doc <- body_add_par(doc, "", style = "Normal")
+      doc <- body_add_par(doc, "Tukey contrasts", style = "heading 1")
+      doc <- body_add_flextable(doc, contrast_ft)
+    }
+  }
+
   doc <- body_add_par(doc, "")
   doc <- body_add_par(doc, sprintf("Generated by Table Analyzer on %s", Sys.Date()))
   doc <- body_add_par(doc, "Significant p-values (< 0.05) in bold.", style = "Normal")
   print(doc, target = file)
+}
+
+prepare_docx_tables <- function(content, response_name = NULL, stratum_label = NULL) {
+  anova_tables <- list()
+  contrast_tables <- list()
+
+  if (!is.null(content$anova_table)) {
+    resp_label <- if (!is.null(response_name)) response_name else "Response"
+    stratum_val <- if (!is.null(stratum_label)) stratum_label else "None"
+
+    anova_tbl <- content$anova_table
+    anova_tbl$Response <- resp_label
+    anova_tbl$Stratum <- stratum_val
+    if (!"Term" %in% names(anova_tbl) && "Effect" %in% names(anova_tbl)) {
+      anova_tbl$Term <- anova_tbl$Effect
+    }
+
+    p_col <- grep("^Pr|p\\.value|p.value", names(anova_tbl), value = TRUE)[1]
+    if (!is.null(p_col) && !"PrF" %in% names(anova_tbl)) {
+      anova_tbl$PrF <- anova_tbl[[p_col]]
+    }
+
+    anova_tables <- list(anova_tbl)
+
+    if (!is.null(content$posthoc_table)) {
+      contrast_tbl <- content$posthoc_table
+      contrast_tbl$Response <- resp_label
+      contrast_tbl$Stratum <- stratum_val
+      contrast_tables <- list(contrast_tbl)
+    }
+  } else if (!is.null(content$anova)) {
+    anova_tables <- content$anova
+    contrast_tables <- content$contrasts
+  } else {
+    anova_tables <- content
+  }
+
+  list(anova = anova_tables, contrasts = contrast_tables)
+}
+
+apply_publication_style <- function(ft, data, merge_cols, sig_rows = integer(0), sig_col = NULL) {
+  ft <- merge_v(ft, j = intersect(merge_cols, ft$col_keys))
+  ft <- fontsize(ft, part = "all", size = 10)
+  ft <- bold(ft, part = "header", bold = TRUE)
+  ft <- color(ft, part = "header", color = "black")
+  ft <- align(ft, align = "center", part = "all")
+
+  if (!is.null(sig_col) && sig_col %in% ft$col_keys && length(sig_rows) > 0) {
+    ft <- bold(ft, i = sig_rows, j = sig_col, bold = TRUE)
+  }
+
+  ft <- border_remove(ft)
+  black <- fp_border(color = "black", width = 1)
+  thin <- fp_border(color = "black", width = 0.5)
+
+  ft <- border(ft, part = "header", border.top = black)
+  ft <- border(ft, part = "header", border.bottom = black)
+
+  if ("Response" %in% names(data)) {
+    resp_index <- which(diff(as.numeric(factor(data$Response))) != 0)
+    if (length(resp_index) > 0) {
+      ft <- border(ft, i = resp_index, part = "body", border.bottom = thin)
+    }
+  }
+
+  if (nrow(data) > 0) {
+    ft <- border(ft, i = nrow(data), part = "body", border.bottom = black)
+  }
+
+  ft <- set_table_properties(ft, layout = "autofit", width = 0.9)
+  ft <- padding(ft, padding.top = 2, padding.bottom = 2, padding.left = 2, padding.right = 2)
+  ft
+}
+
+format_contrast_table <- function(df) {
+  if (is.null(df) || nrow(df) == 0) return(NULL)
+
+  if (!"Response" %in% names(df)) df$Response <- "Response"
+  if (!"Stratum" %in% names(df)) df$Stratum <- "None"
+  if (!"Factor" %in% names(df) && "factor" %in% names(df)) df$Factor <- df$factor
+
+  if (!"Factor" %in% names(df)) {
+    df$Factor <- NA_character_
+  }
+
+  numeric_cols <- names(df)[sapply(df, is.numeric)]
+  if (length(numeric_cols) > 0) {
+    for (col in numeric_cols) {
+      df[[col]] <- round(df[[col]], 3)
+    }
+  }
+
+  p_col <- grep("^p\\.value|^p.value|^p_?value", names(df), value = TRUE)[1]
+  if (is.null(p_col)) return(NULL)
+
+  df$p_label <- ifelse(df[[p_col]] < 0.001, "<0.001", sprintf("%.3f", df[[p_col]]))
+  df$sig <- df[[p_col]] < 0.05
+
+  df
 }
 

--- a/R/anova_shared_ui.R
+++ b/R/anova_shared_ui.R
@@ -167,7 +167,12 @@ bind_single_model_outputs <- function(output, summary_id, download_id,
       if (is.null(results$anova_table)) {
         stop("ANOVA results are unavailable for export.")
       }
-      write_anova_docx(file, results, model_entry$model, response_name, stratum_label)
+      write_anova_docx(
+        file = file,
+        content = results,
+        response_name = response_name,
+        stratum_label = stratum_label
+      )
     }
   )
 }


### PR DESCRIPTION
## Summary
- add Tukey contrast tables to one-way and two-way ANOVA DOCX exports alongside the Type III ANOVA tables
- refactor DOCX writing to share publication-style formatting between ANOVA and contrast outputs
- fix single-model export handler to use the updated DOCX writer API

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230ae09adc832b89963c46d056d8e8)