### PR TITLE
Filter one-way ANOVA contrasts to reference

### DIFF
--- a/R/anova_shared_results.R
+++ b/R/anova_shared_results.R
@@ -53,25 +53,40 @@ prepare_anova_outputs <- function(model_obj, factor_names) {
   posthoc_significant <- numeric(0)
   
   # --- Post-hoc Tukey (one-way or two-way specific) ---
-    if (length(factor_names) == 1) {
-      f1 <- factor_names[1]
-      f1_spec <- anova_protect_vars(f1)
-      if (f1 %in% names(model_obj$model)) {
-        res <- tryCatch({
-          emm <- emmeans::emmeans(model_obj, specs = as.formula(paste("~", f1_spec)))
-          contrasts <- emmeans::contrast(emm, method = "pairwise", adjust = "tukey")
-          as.data.frame(summary(contrasts))
-        }, error = function(e) list(error = e$message))
-      
-      if (is.data.frame(res)) {
-        res$Factor <- f1
-        posthoc_details[[f1]] <- list(table = res, error = NULL)
-        posthoc_combined <- res
-      } else {
-        posthoc_details[[f1]] <- list(table = NULL, error = res$error)
-      }
+  if (length(factor_names) == 1) {
+    f1 <- factor_names[1]
+    f1_spec <- anova_protect_vars(f1)
+
+    res <- list(error = "Factor not found in model object.")
+    if (f1 %in% names(model_obj$model)) {
+      res <- tryCatch({
+        emm <- emmeans::emmeans(model_obj, specs = as.formula(paste("~", f1_spec)))
+        contrasts <- emmeans::contrast(emm, method = "pairwise", adjust = "tukey")
+        summary_df <- as.data.frame(summary(contrasts))
+
+        # Keep only contrasts that involve the reference level (first factor level)
+        levs <- levels(model_obj$model[[f1]])
+        if (!is.null(levs) && length(levs) > 0) {
+          reference <- levs[1]
+          summary_df <- summary_df[
+            grepl(paste0(reference, " - "), summary_df$contrast) |
+              grepl(paste0(" - ", reference), summary_df$contrast),
+            ,
+          ]
+        }
+
+        summary_df
+      }, error = function(e) list(error = e$message))
     }
-    
+
+    if (is.data.frame(res)) {
+      res$Factor <- f1
+      posthoc_details[[f1]] <- list(table = res, error = NULL)
+      posthoc_combined <- res
+    } else {
+      posthoc_details[[f1]] <- list(table = NULL, error = res$error)
+    }
+
   } else if (length(factor_names) == 2) {
     f1 <- factor_names[1]
     f2 <- factor_names[2]


### PR DESCRIPTION
## Summary
- restrict one-way ANOVA post-hoc Tukey contrasts to those involving the reference level when building verbatim output
- add a safe default error when the specified factor is absent from the model

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241e8dbb08832b8e55c7fb675ac012)