### PR TITLE
Fix undefined color levels in PCA biplot

### DIFF
--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -444,6 +444,7 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
       label_size <- ifelse(is.null(input$pca_label_size) || is.na(input$pca_label_size), 2, input$pca_label_size)
       show_loadings <- isTRUE(input$show_loadings)
       loading_scale <- ifelse(is.null(input$loading_scale) || is.na(input$loading_scale), 1.2, input$loading_scale)
+      color_levels <- validate_levels(color_var)
 
       max_levels <- if (exists("MAX_STRATIFICATION_LEVELS")) MAX_STRATIFICATION_LEVELS else 10L
 


### PR DESCRIPTION
## Summary
- initialize color level values for PCA biplots so stratification works without errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241fb36bf0832bbf0c07c4d22a8b3a)