### PR TITLE
Increase margins for stratified ggpairs plots

### DIFF
--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -108,7 +108,8 @@ pairwise_correlation_visualize_ggpairs_server <- function(
           panel.grid.major = ggplot2::element_blank(),
           panel.grid.minor = ggplot2::element_blank(),
           axis.line = ggplot2::element_line(color = "#9ca3af"),
-          axis.ticks = ggplot2::element_line(color = "#9ca3af")
+          axis.ticks = ggplot2::element_line(color = "#9ca3af"),
+          plot.margin = ggplot2::margin(t = 10, r = 14, b = 10, l = 14, unit = "pt")
         )
 
       if (!is.null(title)) p <- p + ggplot2::labs(title = title)


### PR DESCRIPTION
## Summary
- add additional plot margins around ggpairs panels to reduce overlap when combining stratified plots

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242f115ad4832ba2a16d8b576e3522)