### PR TITLE
Increase left margin on pairwise scatterplots

### DIFF
--- a/R/pairwise_correlation_visualize_ggpairs.R
+++ b/R/pairwise_correlation_visualize_ggpairs.R
@@ -109,7 +109,7 @@ pairwise_correlation_visualize_ggpairs_server <- function(
           panel.grid.minor = ggplot2::element_blank(),
           axis.line = ggplot2::element_line(color = "#9ca3af"),
           axis.ticks = ggplot2::element_line(color = "#9ca3af"),
-          plot.margin = ggplot2::margin(t = 10, r = 14, b = 10, l = 14, unit = "pt")
+          plot.margin = ggplot2::margin(t = 10, r = 14, b = 10, l = 24, unit = "pt")
         )
 
       if (!is.null(title)) p <- p + ggplot2::labs(title = title)


### PR DESCRIPTION
## Summary
- increase left margin on pairwise correlation ggpairs subplots for better spacing

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924362e2174832bb35646146b3937a2)