### PR TITLE
Preserve analysis selections across filtering

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -37,10 +37,17 @@ one_way_anova_ui <- function(id) {
 one_way_anova_server <- function(id, filtered_data) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    
+
     responses <- multi_response_server("response", filtered_data)
     strat_info <- stratification_server("strat", filtered_data)
-    
+    data_signature <- reactive({
+      data <- filtered_data()
+      list(
+        names = names(data),
+        classes = vapply(data, function(x) paste(class(x), collapse = "|"), character(1))
+      )
+    })
+
     output$inputs <- renderUI({
       req(filtered_data())
       data <- filtered_data()
@@ -58,8 +65,8 @@ one_way_anova_server <- function(id, filtered_data) {
           "Choose the grouping variable that defines the comparison categories."
         )
       )
-    })
-    
+    }) %>% bindCache(data_signature())
+
     output$level_order <- renderUI({
       req(filtered_data(), input$group)
       levels <- resolve_order_levels(filtered_data()[[input$group]])
@@ -73,7 +80,7 @@ one_way_anova_server <- function(id, filtered_data) {
         ),
         "Arrange the group levels; the first level is used as the reference in outputs."
       )
-    })
+    }) %>% bindCache(list(input$group, data_signature()))
     
     models <- eventReactive(input$run, {
       df <- filtered_data()

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -36,6 +36,13 @@ two_way_anova_server <- function(id, filtered_data) {
     ns <- session$ns
 
     responses <- multi_response_server("response", filtered_data)
+    data_signature <- reactive({
+      data <- filtered_data()
+      list(
+        names = names(data),
+        classes = vapply(data, function(x) paste(class(x), collapse = "|"), character(1))
+      )
+    })
 
     output$inputs <- renderUI({
       req(filtered_data())
@@ -63,7 +70,7 @@ two_way_anova_server <- function(id, filtered_data) {
           "Select the factor for the lines in the interaction plot."
         )
       )
-    })
+    }) %>% bindCache(data_signature())
     
     strat_info <- stratification_server("strat", filtered_data)
     
@@ -83,8 +90,8 @@ two_way_anova_server <- function(id, filtered_data) {
         ),
         sprintf("Arrange the levels of %s for the x-axis; the first level is the reference.", input$factor1)
       )
-    })
-    
+    }) %>% bindCache(list(input$factor1, data_signature()))
+
     output$level_order_2 <- renderUI({
       req(filtered_data(), input$factor2)
       levels2 <- resolve_order_levels(filtered_data()[[input$factor2]])
@@ -98,7 +105,7 @@ two_way_anova_server <- function(id, filtered_data) {
         ),
         sprintf("Arrange the levels of %s for the line colours; the first level is the reference.", input$factor2)
       )
-    })
+    }) %>% bindCache(list(input$factor2, data_signature()))
     
     # -----------------------------------------------------------
     # Model fitting (via shared helper)

--- a/R/descriptive_analysis.R
+++ b/R/descriptive_analysis.R
@@ -32,6 +32,13 @@ descriptive_server <- function(id, filtered_data) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     df <- filtered_data
+    data_signature <- reactive({
+      data <- df()
+      list(
+        names = names(data),
+        classes = vapply(data, function(x) paste(class(x), collapse = "|"), character(1))
+      )
+    })
 
     # ------------------------------------------------------------
     # Dynamic inputs
@@ -52,7 +59,7 @@ descriptive_server <- function(id, filtered_data) {
           "Choose the numeric measurements you want to summarise (mean, SD, etc.)."
         )
       )
-    })
+    }) %>% bindCache(data_signature())
     
     strat_info <- stratification_server("strat", df)
     

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -34,6 +34,13 @@ ggpairs_server <- function(id, data_reactive) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     df <- reactive(data_reactive())
+    data_signature <- reactive({
+      data <- df()
+      list(
+        names = names(data),
+        classes = vapply(data, function(x) paste(class(x), collapse = "|"), character(1))
+      )
+    })
 
     strat_info <- stratification_server("strat", df)
 
@@ -46,7 +53,7 @@ ggpairs_server <- function(id, data_reactive) {
         selectInput(ns("vars"), "Numeric variables", choices = num_vars, selected = num_vars, multiple = TRUE),
         "Choose which numeric columns to include in the correlation matrix."
       )
-    })
+    }) %>% bindCache(data_signature())
 
     build_ggpairs_object <- function(data) {
       GGally::ggpairs(

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -38,6 +38,13 @@ pca_server <- function(id, filtered_data) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     df <- reactive(filtered_data())
+    data_signature <- reactive({
+      data <- df()
+      list(
+        names = names(data),
+        classes = vapply(data, function(x) paste(class(x), collapse = "|"), character(1))
+      )
+    })
 
     # Dynamically populate numeric variable list (re-rendered with UI)
     output$vars_ui <- renderUI({
@@ -48,7 +55,7 @@ pca_server <- function(id, filtered_data) {
         selectInput(ns("vars"), "Numeric variables", choices = num_vars, selected = num_vars, multiple = TRUE),
         "Pick the numeric variables whose combined patterns you want PCA to capture."
       )
-    })
+    }) %>% bindCache(data_signature())
 
     `%||%` <- function(x, y) if (is.null(x)) y else x
 

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -392,6 +392,13 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     strat_info <- stratification_server("strat", data)
+    data_signature <- reactive({
+      df <- data()
+      list(
+        names = names(df),
+        classes = vapply(df, function(x) paste(class(x), collapse = "|"), character(1))
+      )
+    })
 
     if (allow_multi_response) {
       selected_responses <- multi_response_server("response", data)
@@ -403,7 +410,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
           selectInput(ns("dep"), "Response variable (numeric)", choices = types$num),
           "Choose the outcome that the model should predict."
         )
-      })
+      }) %>% bindCache(data_signature())
 
       selected_responses <- reactive({
         req(input$dep)
@@ -423,7 +430,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         ),
         "Pick factor variables that might explain differences in the response."
       )
-    })
+    }) %>% bindCache(data_signature())
 
     output$level_order <- renderUI({
       req(data())
@@ -450,7 +457,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
           )
         })
       )
-    })
+    }) %>% bindCache(list(input$fixed, data_signature()))
 
     output$covar_selector <- renderUI({
       req(data())
@@ -464,7 +471,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
         ),
         "Pick numeric predictors that could help explain the response."
       )
-    })
+    }) %>% bindCache(data_signature())
 
     if (engine == "lmm") {
       output$random_selector <- renderUI({
@@ -479,14 +486,14 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
           ),
           "Choose a grouping factor for random intercepts in the mixed model."
         )
-      })
+      }) %>% bindCache(data_signature())
     }
 
     output$interaction_select <- renderUI({
       req(data())
       types <- reg_detect_types(data())
       reg_interactions_ui(ns, input$fixed, types$fac)
-    })
+    }) %>% bindCache(list(input$fixed, data_signature()))
 
     output$formula_preview <- renderUI({
       responses <- selected_responses()


### PR DESCRIPTION
## Summary
- prevent analysis sidebar widgets from rerendering when only filter results change by caching based on data structure
- apply the caching across descriptive, ANOVA, regression, PCA, and correlation analysis modules to preserve user selections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243738c0f8832b87016f3df9acc932)