### PR TITLE
Add generalized linear model option with simplified controls

### DIFF
--- a/R/glm_analysis.R
+++ b/R/glm_analysis.R
@@ -1,0 +1,7 @@
+# ===============================================================
+# 🔬 Generalized Linear Model (GLM)
+# ===============================================================
+
+glm_ui <- function(id) regression_ui(id, "glm", allow_multi_response = FALSE, compact = TRUE)
+
+glm_server <- function(id, data) regression_server(id, data, "glm", allow_multi_response = FALSE, compact = TRUE)

--- a/R/module_analysis.R
+++ b/R/module_analysis.R
@@ -31,7 +31,8 @@ analysis_ui <- function(id) {
               "One-way ANOVA" = "One-way ANOVA",
               "Two-way ANOVA" = "Two-way ANOVA",
               "Linear Model (LM)" = "Linear Model (LM)",
-              "Linear Mixed Model (LMM)" = "Linear Mixed Model (LMM)"
+              "Linear Mixed Model (LMM)" = "Linear Mixed Model (LMM)",
+              "Generalized Linear Model (GLM)" = "Generalized Linear Model (GLM)"
             ),
             "Multivariate" = c(
               "Pairwise Correlation" = "Pairwise Correlation",
@@ -66,6 +67,7 @@ analysis_server <- function(id, filtered_data) {
       "Two-way ANOVA"          = list(id = "anova2", ui = two_way_anova_ui, server = two_way_anova_server, type = "anova2"),
       "Linear Model (LM)"      = list(id = "lm",     ui = lm_ui, server = lm_server, type = "lm"),
       "Linear Mixed Model (LMM)" = list(id = "lmm",  ui = lmm_ui, server = lmm_server, type = "lmm"),
+      "Generalized Linear Model (GLM)" = list(id = "glm", ui = glm_ui, server = glm_server, type = "glm"),
       "Pairwise Correlation"   = list(id = "pairs",  ui = ggpairs_ui, server = ggpairs_server, type = "pairs"),
       "PCA"                    = list(id = "pca",    ui = pca_ui, server = pca_server, type = "pca")
     )
@@ -88,6 +90,7 @@ analysis_server <- function(id, filtered_data) {
         anova1 = "ANOVA",
         anova2 = "ANOVA",
         lm = "LM",
+        glm = "GLM",
         lmm = "LMM",
         pairs = "CORR",
         pca = "PCA"

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -1,5 +1,5 @@
 # ===============================================================
-# 🧬 Common module for LM and LMM
+# 🧬 Common module for LM, LMM, and GLM
 # ===============================================================
 
 reg_diagnostic_explanation <- paste(
@@ -10,7 +10,7 @@ reg_diagnostic_explanation <- paste(
   "If you spot strong patterns in either plot, consider transforming variables, adding predictors, or trying a different model to improve the fit."
 )
 
-fit_all_models <- function(df, responses, rhs, strat_details, engine, allow_multi_response) {
+fit_all_models <- function(df, responses, rhs, strat_details, engine, allow_multi_response, glm_family = NULL) {
   safe_fit <- purrr::safely(reg_fit_model)
 
   make_entry <- function(label = NULL, display = label, model = NULL, error = NULL) {
@@ -49,7 +49,7 @@ fit_all_models <- function(df, responses, rhs, strat_details, engine, allow_mult
 
   for (resp in responses) {
     if (is.null(strat_details$var)) {
-      result <- safe_fit(resp, rhs, df, engine = engine)
+      result <- safe_fit(resp, rhs, df, engine = engine, glm_family = glm_family)
       strata_entry <- make_entry(display = "Overall")
 
       if (is.null(result$error)) {
@@ -72,7 +72,7 @@ fit_all_models <- function(df, responses, rhs, strat_details, engine, allow_mult
         if (nrow(subset_data) == 0) {
           entry$error <- paste0("No observations available for stratum '", level, "'.")
         } else {
-          result <- safe_fit(resp, rhs, subset_data, engine = engine)
+          result <- safe_fit(resp, rhs, subset_data, engine = engine, glm_family = glm_family)
           if (is.null(result$error)) {
             entry$model <- result$result
             successful_strata[[level]] <- result$result
@@ -131,15 +131,18 @@ fit_all_models <- function(df, responses, rhs, strat_details, engine, allow_mult
 render_model_summary <- function(engine, model_obj) {
   if (engine == "lm") {
     reg_display_lm_summary(model_obj)
+  } else if (engine == "glm") {
+    reg_display_glm_summary(model_obj)
   } else {
     reg_display_lmm_summary(model_obj)
   }
 }
 
-render_residual_plot <- function(model_obj) {
+render_residual_plot <- function(model_obj, engine) {
+  resid_type <- if (engine == "glm") "deviance" else "response"
   plot_df <- data.frame(
     fitted = stats::fitted(model_obj),
-    residuals = stats::residuals(model_obj)
+    residuals = stats::residuals(model_obj, type = resid_type)
   )
 
   ggplot2::ggplot(plot_df, ggplot2::aes(x = fitted, y = residuals)) +
@@ -159,8 +162,8 @@ render_residual_plot <- function(model_obj) {
     )
 }
 
-render_qq_plot <- function(model_obj) {
-  resid_vals <- stats::residuals(model_obj)
+render_qq_plot <- function(model_obj, engine) {
+  resid_vals <- stats::residuals(model_obj, type = if (engine == "glm") "deviance" else "response")
   qq_base <- stats::qqnorm(resid_vals, plot.it = FALSE)
   
   qq_df <- data.frame(
@@ -218,11 +221,11 @@ assign_model_outputs <- function(output, engine, response, idx, model_obj, strat
   })
 
   output[[resid_id]] <- renderPlot({
-    render_residual_plot(model_obj)
+    render_residual_plot(model_obj, engine)
   })
 
   output[[qq_id]] <- renderPlot({
-    render_qq_plot(model_obj)
+    render_qq_plot(model_obj, engine)
   })
 
   assign_download_handler(output, download_id, engine, response, stratum_display, model_obj)
@@ -348,26 +351,30 @@ render_model_outputs <- function(output, models_info, engine) {
   }
 }
 
-regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FALSE) {
+regression_ui <- function(id, engine = c("lm", "lmm", "glm"), allow_multi_response = FALSE, compact = FALSE) {
   ns <- NS(id)
   engine <- match.arg(engine)
   allow_multi_response <- isTRUE(allow_multi_response)
+  compact <- isTRUE(compact)
 
   list(
     config = tagList(
       if (allow_multi_response) multi_response_ui(ns("response")) else uiOutput(ns("response_ui")),
       uiOutput(ns("fixed_selector")),
-      uiOutput(ns("level_order")),
+      if (!compact) uiOutput(ns("level_order")),
       uiOutput(ns("covar_selector")),
       if (engine == "lmm") uiOutput(ns("random_selector")),
-      uiOutput(ns("interaction_select")),
+      if (engine == "glm") uiOutput(ns("family_selector")),
+      if (!compact) uiOutput(ns("interaction_select")),
       uiOutput(ns("formula_preview")),
       br(),
-      tags$details(
-        tags$summary(strong("Advanced options")),
-        stratification_ui("strat", ns)
+      if (!compact) tagList(
+        tags$details(
+          tags$summary(strong("Advanced options")),
+          stratification_ui("strat", ns)
+        ),
+        br()
       ),
-      br(),
       fluidRow(
         column(6, with_help_tooltip(
           actionButton(ns("run"), "Show results", width = "100%"),
@@ -385,13 +392,14 @@ regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FA
   )
 }
 
-regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_response = FALSE) {
+regression_server <- function(id, data, engine = c("lm", "lmm", "glm"), allow_multi_response = FALSE, compact = FALSE) {
   engine <- match.arg(engine)
   allow_multi_response <- isTRUE(allow_multi_response)
+  compact <- isTRUE(compact)
 
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    strat_info <- stratification_server("strat", data)
+    strat_info <- if (compact) reactive(list(var = NULL, levels = NULL)) else stratification_server("strat", data)
 
     if (allow_multi_response) {
       selected_responses <- multi_response_server("response", data)
@@ -399,8 +407,10 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       output$response_ui <- renderUI({
         req(data())
         types <- reg_detect_types(data())
+        response_choices <- if (engine == "glm") unique(c(types$num, types$fac)) else types$num
+        label <- if (engine == "glm") "Response variable" else "Response variable (numeric)"
         with_help_tooltip(
-          selectInput(ns("dep"), "Response variable (numeric)", choices = types$num),
+          selectInput(ns("dep"), label, choices = response_choices),
           "Choose the outcome that the model should predict."
         )
       })
@@ -432,7 +442,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       df <- data()
       fac_vars <- input$fixed
 
-      if (length(fac_vars) == 0) return(NULL)
+      if (compact || length(fac_vars) == 0) return(NULL)
 
       tagList(
         lapply(fac_vars, function(var) {
@@ -484,8 +494,26 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
 
     output$interaction_select <- renderUI({
       req(data())
+      if (compact) return(NULL)
       types <- reg_detect_types(data())
       reg_interactions_ui(ns, input$fixed, types$fac)
+    })
+
+    output$family_selector <- renderUI({
+      req(engine == "glm")
+      with_help_tooltip(
+        selectInput(
+          ns("family"),
+          "GLM family",
+          choices = c(
+            "Gaussian (identity)" = "gaussian",
+            "Binomial (logit)" = "binomial",
+            "Poisson (log)" = "poisson"
+          ),
+          selected = "gaussian"
+        ),
+        "Pick the link family that matches your outcome distribution."
+      )
     })
 
     output$formula_preview <- renderUI({
@@ -506,7 +534,11 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       df <- data()
       responses <- selected_responses()
       req(length(responses) > 0)
-      validate_numeric_columns(df, responses, "response variable(s)")
+      if (engine != "glm") {
+        validate_numeric_columns(df, responses, "response variable(s)")
+      } else {
+        validate_glm_response(df, responses, input$family)
+      }
 
       rhs <- reg_compose_rhs(
         input$fixed,
@@ -517,7 +549,7 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       )
 
       strat_details <- strat_info()
-      fit_all_models(df, responses, rhs, strat_details, engine, allow_multi_response)
+      fit_all_models(df, responses, rhs, strat_details, engine, allow_multi_response, glm_family = input$family)
     })
 
     output$results_ui <- renderUI({
@@ -614,8 +646,8 @@ regression_server <- function(id, data, engine = c("lm", "lmm"), allow_multi_res
       data_used <- df_final()
 
       list(
-        analysis_type = if (engine == "lm") "LM" else "LMM",
-        type = if (engine == "lm") "lm" else "lmm",
+        analysis_type = if (engine == "lm") "LM" else if (engine == "glm") "GLM" else "LMM",
+        type = if (engine == "lm") "lm" else if (engine == "glm") "glm" else "lmm",
         data_used = data_used,
         model = model_fit(),
         summary = summary_table(),


### PR DESCRIPTION
## Summary
- add a generalized linear model analysis option after LMM
- streamline GLM sidebar controls with core predictors and family selector
- extend regression utilities to fit and summarize GLM models

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692456fda1cc832baa1019c8eed9fca4)