### PR TITLE
Ensure ANOVA barplot p-value labels stay visible

### DIFF
--- a/R/anova_shared_barplots.R
+++ b/R/anova_shared_barplots.R
@@ -586,11 +586,12 @@ add_significance_after_build <- function(p,
   if (is.null(ann) || nrow(ann) == 0) return(p)
   
   max_y_text <- max(ann$y, na.rm = TRUE)
-  
+
   p_build <- ggplot_build(p)
   current_limits <- p_build$layout$panel_params[[1]]$y.range
-  
-  new_upper <- max(current_limits[2], max_y_text * 1.05)
+
+  padding <- compute_annotation_offset(barpos$y, offset_mult = 0.12)
+  new_upper <- max(current_limits[2], max_y_text + padding)
   
   p +
     scale_y_continuous(


### PR DESCRIPTION
## Summary
- add extra padding when recalculating y-axis limits for ANOVA barplots
- prevent p-value annotations from being clipped when attached to the tallest bars

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246af9f610832b880ce9f28609a363)