### PR TITLE
Preserve two-way ANOVA posthoc level order

### DIFF
--- a/R/anova_shared_results.R
+++ b/R/anova_shared_results.R
@@ -115,12 +115,19 @@ prepare_anova_outputs <- function(model_obj, factor_names) {
       
       df <- as.data.frame(summary(contrasts_nested))
       df$Factor <- paste0(f2, "_within_", f1)
-      
+
       # Ensure f1 column exists (grouping variable)
       if (!f1 %in% names(df)) {
         df[[f1]] <- df$comparison # fallback: emmeans puts group there
       }
-      
+
+      # Preserve the user-specified order of the grouping factor
+      f1_levels <- levels(model_obj$model[[f1]])
+      if (!is.null(f1_levels)) {
+        df[[f1]] <- factor(df[[f1]], levels = f1_levels)
+        df <- df[order(df[[f1]]), , drop = FALSE]
+      }
+
       df[[f1]] <- as.character(df[[f1]])
       df
       


### PR DESCRIPTION
## Summary
- ensure two-way ANOVA post-hoc Tukey output preserves the user-specified grouping order when nesting contrasts
- reorder nested post-hoc tables using the factor levels stored in the fitted model

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247d7fa51c832b831635b8af0c7564)