### PR TITLE
Add stratum separators to ANOVA docx tables

### DIFF
--- a/R/anova_shared_results.R
+++ b/R/anova_shared_results.R
@@ -317,7 +317,14 @@ write_anova_docx <- function(content, file, response_name = NULL, stratum_label 
     black <- fp_border(color = "black", width = 1)
     ft <- border(ft, part = "header", border.top = black, border.bottom = black)
 
-    if ("Response" %in% names(df)) {
+    if ("Stratum" %in% names(df)) {
+      group_cols <- c(if ("Response" %in% names(df)) "Response", "Stratum")
+      strata_factor <- interaction(df[, group_cols, drop = FALSE], drop = TRUE)
+      change_rows <- which(diff(as.numeric(strata_factor)) != 0)
+      if (length(change_rows) > 0) {
+        ft <- border(ft, i = change_rows, part = "body", border.bottom = fp_border(color = "black", width = 0.5))
+      }
+    } else if ("Response" %in% names(df)) {
       change_rows <- which(diff(as.numeric(factor(df$Response))) != 0)
       if (length(change_rows) > 0) {
         ft <- border(ft, i = change_rows, part = "body", border.bottom = fp_border(color = "black", width = 0.5))


### PR DESCRIPTION
## Summary
- add per-stratum borders in ANOVA Type III tables within docx exports
- ensure contrast tables also render horizontal separators between strata for stratified models

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247f0ee114832b879459aff3291dc2)