### PR TITLE
Prevent duplicate PCA variable validation

### DIFF
--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -50,6 +50,14 @@ pca_server <- function(id, filtered_data) {
       )
     })
 
+    selected_numeric_vars <- reactive({
+      data <- req(df())
+      numeric_vars <- names(data)[vapply(data, is.numeric, logical(1))]
+      intersect(input$vars, numeric_vars)
+    })
+
+    has_enough_numeric_vars <- reactive(length(selected_numeric_vars()) > 1)
+
     `%||%` <- function(x, y) if (is.null(x)) y else x
 
     format_usage_line <- function(entry) {
@@ -134,9 +142,8 @@ pca_server <- function(id, filtered_data) {
       data <- df()
       validate(need(nrow(data) > 0, "No data available for PCA."))
 
-      numeric_vars <- names(data)[vapply(data, is.numeric, logical(1))]
-      selected_vars <- intersect(input$vars, numeric_vars)
-      validate(need(length(selected_vars) > 1, "Select at least two numeric variables for PCA."))
+      selected_vars <- selected_numeric_vars()
+      validate(need(has_enough_numeric_vars(), "Select at least two numeric variables for PCA."))
 
       result <- run_pca_on_subset(data, selected_vars)
 
@@ -287,6 +294,7 @@ pca_server <- function(id, filtered_data) {
     })
 
     output$excluded_rows_section <- renderUI({
+      req(has_enough_numeric_vars())
       results <- pca_result()
       req(results)
 
@@ -302,6 +310,7 @@ pca_server <- function(id, filtered_data) {
     })
 
     output$excluded_table <- DT::renderDT({
+      req(has_enough_numeric_vars())
       results <- pca_result()
       req(results)
       


### PR DESCRIPTION
## Summary
- add shared selected-numeric-variable tracking for PCA analysis
- gate excluded rows/table rendering to avoid repeating variable selection validation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925bacabebc832ba40060bb1adf9a4b)