### PR TITLE
Rename download buttons to 'Download results'

### DIFF
--- a/R/anova_oneway_analysis.R
+++ b/R/anova_oneway_analysis.R
@@ -24,7 +24,7 @@ one_way_anova_ui <- function(id) {
         column(
           6,
           with_help_tooltip(
-            downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"),
+            downloadButton(ns("download_all"), "Download results", style = "width: 100%;"),
             "Export the ANOVA summaries, post-hoc tests, and diagnostics."
           )
         )

--- a/R/anova_twoway_analysis.R
+++ b/R/anova_twoway_analysis.R
@@ -20,7 +20,7 @@ two_way_anova_ui <- function(id) {
           "Fit the two-way ANOVA with the selected factors and responses."
         )),
         column(6, with_help_tooltip(
-          downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"),
+          downloadButton(ns("download_all"), "Download results", style = "width: 100%;"),
           "Save all ANOVA tables, post-hoc results, and diagnostics to disk."
         ))
       )

--- a/R/pairwise_correlation_analysis.R
+++ b/R/pairwise_correlation_analysis.R
@@ -18,7 +18,7 @@ ggpairs_ui <- function(id) {
           "Calculate the correlation coefficients for the selected variables."
         )),
         column(6, with_help_tooltip(
-          downloadButton(ns("download_model"), "Download all results", style = "width: 100%;"),
+          downloadButton(ns("download_model"), "Download results", style = "width: 100%;"),
           "Export the correlation matrices and any messages to a text file."
         ))
       )

--- a/R/pca_analysis.R
+++ b/R/pca_analysis.R
@@ -21,7 +21,7 @@ pca_ui <- function(id) {
           "Compute the principal components for the selected variables."
         )),
         column(6, with_help_tooltip(
-          downloadButton(ns("download_all"), "Download all results", style = "width: 100%;"),
+          downloadButton(ns("download_all"), "Download results", style = "width: 100%;"),
           "Export the PCA summaries, loadings, and diagnostics to a text file."
         ))
       )

--- a/R/regression_analysis.R
+++ b/R/regression_analysis.R
@@ -352,7 +352,7 @@ regression_ui <- function(id, engine = c("lm", "lmm"), allow_multi_response = FA
           "Fit the model using the chosen predictors and options."
         )),
         column(6, with_help_tooltip(
-          downloadButton(ns("download_model"), "Download all results", style = "width: 100%;"),
+          downloadButton(ns("download_model"), "Download results", style = "width: 100%;"),
           "Export the model outputs, tables, and summaries to your computer."
         ))
       )

--- a/README.html
+++ b/README.html
@@ -431,7 +431,7 @@ selections to create the analysis-ready subset.</li>
 <li>Choose a module and configure responses, predictors, covariates,
 interactions, stratification, and (for LMM) random intercepts.</li>
 <li>Click <strong>Show results</strong> to run the model; export
-everything with <strong>Download all results</strong>.</li>
+everything with <strong>Download results</strong>.</li>
 </ul></li>
 <li><strong>Visualize</strong> (Tab “4️⃣ Visualize”)
 <ul>
@@ -474,7 +474,7 @@ modules; for best readability, keep stratum levels to ≲10.</li>
 <div id="exports-reporting" class="section level2">
 <h2>📦 Exports &amp; reporting</h2>
 <ul>
-<li>Every module exposes a “Download all results” button that bundles
+<li>Every module exposes a “Download results” button that bundles
 the text outputs currently displayed.</li>
 <li>LM/LMM exports generate Word (<code>.docx</code>) reports with ANOVA
 tables, model coefficients, random-effects variance (if applicable), and

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Table Analyzer is a modular R/Shiny application for analysing tabular datasets w
    - Pick the columns you care about and adjust numeric ranges or factor selections to create the analysis-ready subset.
 3. **Analyze** (Tab “3️⃣ Analyze”)
    - Choose a module and configure responses, predictors, covariates, interactions, stratification, and (for LMM) random intercepts.
-   - Click **Show results** to run the model; export everything with **Download all results**.
+   - Click **Show results** to run the model; export everything with **Download results**.
 4. **Visualize** (Tab “4️⃣ Visualize”)
    - Explore plots tailored to the active analysis, including multi-panel layouts for stratified fits and customizable color themes.
 
@@ -66,7 +66,7 @@ shiny::runApp(".")
 
 ## 📦 Exports & reporting
 
-- Every module exposes a “Download all results” button that bundles the text outputs currently displayed; model tables use publication-style formatting with top and bottom rules for the header and a closing border at the table foot.
+- Every module exposes a “Download results” button that bundles the text outputs currently displayed; model tables use publication-style formatting with top and bottom rules for the header and a closing border at the table foot.
 - LM/LMM exports generate Word (`.docx`) reports with ANOVA tables, model coefficients, random-effects variance (if applicable), and ICC summaries rendered with the same publication-style borders.
 - All plots download as publication-ready PNG files (300 dpi) with customizable width and height; PCA, correlation, and descriptive visuals can also be saved via each plot’s built-in controls.
 


### PR DESCRIPTION
## Summary
- rename analysis module download buttons to say "Download results"
- update README documentation to reflect new label

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c666fb04832b9640cc2938a93db4)