### PR TITLE
Darken home hero panel

### DIFF
--- a/app.R
+++ b/app.R
@@ -37,7 +37,8 @@ ui <- navbarPage(
     tags$style(HTML("
       .container-fluid { max-width: 100%; margin: auto; }
       .hero {
-        background: linear-gradient(135deg, #f8f9fa 0%, #e9f5ff 100%);
+        background: linear-gradient(135deg, #eef1f5 0%, #d9e7f7 100%);
+        border: 1px solid #d0d9e5;
         border-radius: 16px;
         padding: 40px 24px;
         margin-top: 20px;


### PR DESCRIPTION
## Summary
- darken the home page hero background gradient and add a subtle border to emphasize the welcome area

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4c5f9e34832bb97bc88ddb8c0f8e)