### PR TITLE
Maintain PCA color levels across facets

### DIFF
--- a/R/pca_visualize.R
+++ b/R/pca_visualize.R
@@ -574,7 +574,7 @@ visualize_pca_server <- function(id, filtered_data, model_fit) {
           loading_scale = loading_scale,
           custom_colors = custom_colors(),
           subset_rows = idx,
-          color_levels = NULL,
+          color_levels = color_level_order(),
           x_limits = x_limits,
           y_limits = y_limits,
           base_size = base_size()


### PR DESCRIPTION
## Summary
- preserve the global color level ordering when drawing PCA biplots
- ensure faceted PCA plots retain consistent color mapping across panels

## Testing
- not run (R not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b53756300832b9a5dbf782f96a8b7)