### PR TITLE
Match home hero background to sidebar style

### DIFF
--- a/app.R
+++ b/app.R
@@ -37,8 +37,8 @@ ui <- navbarPage(
     tags$style(HTML("
       .container-fluid { max-width: 100%; margin: auto; }
       .hero {
-        background: linear-gradient(135deg, #eef1f5 0%, #d9e7f7 100%);
-        border: 1px solid #d0d9e5;
+        background: #ecf0f1;
+        border: 1px solid #dce4ec;
         border-radius: 16px;
         padding: 40px 24px;
         margin-top: 20px;


### PR DESCRIPTION
## Summary
- change the home page hero to use the sidebar background color
- adjust the hero border to align with the sidebar styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b6b7d8360832b97a5cae976e79a9f)